### PR TITLE
Change the logging channel to stable

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,7 +1,7 @@
 parameters:
   openshift4_logging:
     namespace: openshift-logging
-    channel: '4.5'
+    channel: 'stable'
     clusterLogging:
       managementState: Managed
       logStore:

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -18,9 +18,12 @@ The namespace in which to install the operator.
 
 [horizontal]
 type:: string
-default:: `4.5`
+default:: `stable`
 
 Channel of the operator subscription to use.
+In OpenShift 4.7 Red Hat introduced an OpenShift version independent logging stack starting with the version 5.0.
+Since version 5.1 there are two channels stable and stable-5.x.
+Choosing the stable channel allows never have to care about the interoperability as the specific OpenShift version delivers the right version via the operator marketplace.
 
 
 == `clusterLogging`

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -25,6 +25,8 @@ In OpenShift 4.7 Red Hat introduced an OpenShift version independent logging sta
 Since version 5.1 there are two channels stable and stable-5.x.
 Choosing the stable channel allows never have to care about the interoperability as the specific OpenShift version delivers the right version via the operator marketplace.
 
+See the https://docs.openshift.com/container-platform/latest/logging/cluster-logging-deploying.html#cluster-logging-deploy-cli_cluster-logging-deploying[OpenShift documentation] for details.
+
 
 == `clusterLogging`
 


### PR DESCRIPTION
In OpenShift 4.7 Red Hat introduced an OpenShift version independent
logging stack starting with the version 5.0. Since version 5.1 there
are two channels stable and stable-5.1. Choosing the stable channel
allows never have to care about the interoperability as the specific
OpenShift version delivers the right version via the operator
marketplace.

## Checklist

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
