### PR TITLE
Remove audit-logs pipeline from log forwarding

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -87,11 +87,6 @@ local clusterLoggingGroupVersion = 'logging.openshift.io/v1';
     } + com.makeMergeable({
       pipelines: [
         {
-          name: 'audit-logs',
-          inputRefs: [ 'audit' ],
-          outputRefs: [ 'default' ],
-        },
-        {
           name: 'infrastructure-logs',
           inputRefs: [ 'infrastructure' ],
           outputRefs: [ 'default' ],


### PR DESCRIPTION
If cluster log forwarding is enabled with the audit-logs pipeline the log storage quickly fills up with audit logs.
Removing the pipeline as audit-logs are not enabled in the default config either.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [ ] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [ ] Link this PR to related issues.

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
