### PR TITLE
Alerting: Predict Elasticsearch storage watermark reached

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -3,6 +3,13 @@ parameters:
     namespace: openshift-logging
     channel: 'stable'
     alerts: 'master'
+    predict_elasticsearch_storage_alert:
+      enabled: true
+      lookback_range: 72h
+      predict_hours_from_now: 72
+      threshold: 85
+      for: 6h
+      severity: warning
     ignore_alerts: []
     clusterLogging:
       managementState: Managed

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -36,6 +36,79 @@ default:: `master`
 Release version of the alerting rules.
 Should be adjusted according to the channel: If you specify `channel: stable-5.2` use `alerts: release-5.2`.
 
+== `predict_elasticsearch_storage_alert`
+
+[horizontal]
+type:: dict
+example::
++
+[source,yaml]
+----
+predict_elasticsearch_storage_alert:
+  enabled: true
+  lookback_range: 72h
+  predict_hours_from_now: 72
+  threshold: 85
+  for: 6h
+  severity: warning
+----
+
+Create an alert `SYN_ElasticsearchExpectNodeToReachDiskWatermark` if the storage allocated for Elasticsearch is predicted to reach the low storage watermark.
+
+=== `predict_elasticsearch_storage_alert.enabled`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Enable or disable this alert.
+
+=== `predict_elasticsearch_storage_alert.lookback_range`
+
+[horizontal]
+type:: prometheus duration
+default:: `72h`
+
+How for to look back to calculate the prediction.
+
+
+=== `predict_elasticsearch_storage_alert.predict_hours_from_now`
+
+[horizontal]
+type:: number
+default:: `72`
+
+How far in the future the prediction is calculated.
+
+
+=== `predict_elasticsearch_storage_alert.threshold`
+
+[horizontal]
+type:: number
+default:: `85`
+
+The threshold for the alert.
+Percentage of disk fill.
+
+
+=== `predict_elasticsearch_storage_alert.for`
+
+[horizontal]
+type:: prometheus duration
+default:: `6h`
+
+The alert is firing once the threshold has been reached for this long.
+
+
+=== `predict_elasticsearch_storage_alert.severity`
+
+[horizontal]
+type:: string
+default:: `warning`
+
+The severity of the fired alert.
+
+
 == `ignore_alerts`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.adoc
+++ b/docs/modules/ROOT/pages/runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.adoc
@@ -1,0 +1,14 @@
+= Alert rule: SYN_ElasticsearchExpectNodeToReachDiskWatermark
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+This alert fires when the Elasticsearch node storage utilization is expected to reach the disk low watermark.
+The default watermark is 85%.
+The node will become read-only at the watermark.
+To resolve this alert, unused data should be deleted or the https://kb.vshn.ch/oc4/how-tos/logging/increase-elasticsearch-storage-size.html[disk size must be increased].
+
+== icon:bug[] Steps for debugging
+
+// Add detailed steps to debug and resolve the issue

--- a/docs/modules/ROOT/pages/runbooks/_RuleTemplate.adoc
+++ b/docs/modules/ROOT/pages/runbooks/_RuleTemplate.adoc
@@ -1,0 +1,11 @@
+= Alert rule: ${rule}
+
+include::partial$runbooks/contribution_note.adoc[]
+
+== icon:glasses[] Overview
+
+// Add overview over the condition which triggers the rule
+
+== icon:bug[] Steps for debugging
+
+// Add detailed steps to debug and resolve the issue

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -5,3 +5,6 @@
 
 .How-Tos
 * xref:how-tos/upgrade-v0.1-v1.x.adoc[Upgrade from v0.1.0 to v1.x]
+
+.Alert runbooks
+* xref:runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.adoc[SYN_ElasticsearchExpectNodeToReachDiskWatermark]

--- a/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
+++ b/docs/modules/ROOT/partials/runbooks/contribution_note.adoc
@@ -1,0 +1,5 @@
+[NOTE]
+====
+Please consider opening a PR to improve this runbook if you gain new information about causes of the alert, or how to debug or resolve the alert.
+Click "Edit this Page" in the top right corner to create a PR directly on GitHub.
+====


### PR DESCRIPTION
Fire alert `SYN_ElasticsearchExpectNodeToReachDiskWatermark` if the disk storage on a node is predicted to run out.

Includes runbook.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist below.

Contributors guide: ./CONTRIBUTING.md
-->

## Checklist
<!--
Remove items that do not apply. For completed items, change [ ] to [x].
-->

- [x] Keep pull requests small so they can be easily reviewed.
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog

<!--
NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
