### PR TITLE
Add logic to configure ServiceMonitors

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,6 +16,7 @@ parameters:
     ignore_alerts: []
     monitoring:
       enabled: true
+      instance: ''
 
     clusterLogging:
       managementState: Managed

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -11,7 +11,12 @@ parameters:
       threshold: 85
       for: 6h
       severity: warning
+
+    # TBD: move to `monitoring` key?
     ignore_alerts: []
+    monitoring:
+      enabled: true
+
     clusterLogging:
       managementState: Managed
       logStore:

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -17,6 +17,10 @@ parameters:
     monitoring:
       enabled: true
       instance: ''
+      enableServiceMonitors:
+        cluster-logging-operator: true
+        fluentd: true
+        elasticsearch-cluster: true
 
     clusterLogging:
       managementState: Managed

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,7 +16,7 @@ parameters:
     ignore_alerts: []
     monitoring:
       enabled: true
-      instance: ''
+      instance: null
       enableServiceMonitors:
         cluster-logging-operator: true
         fluentd: true

--- a/component/alertrules.libsonnet
+++ b/component/alertrules.libsonnet
@@ -12,32 +12,9 @@ assert
   std.member(inv.applications, 'prometheus')
   : 'neither component `openshift4-monitoring` nor `prometheus` enabled';
 
-// Function to process an array which supports removing previously added
-// elements by prefixing them with ~
-local render_array(arr) =
-  // extract real value of array entry
-  local realval(v) = std.lstripChars(v, '~');
-  // Compute whether each element should be included by keeping track of
-  // whether its last occurrence in the input array was prefixed with ~ or
-  // not.
-  local val_state = std.foldl(
-    function(a, it) a + it,
-    [
-      { [realval(v)]: !std.startsWith(v, '~') }
-      for v in arr
-    ],
-    {}
-  );
-  // Return filtered array containing only elements whose last occurrence
-  // wasn't prefixed by ~.
-  std.filter(
-    function(val) val_state[val],
-    std.objectFields(val_state)
-  );
-
 // Keep only alerts from params.ignore_alerts for which the last
 // array entry wasn't prefixed with `~`.
-local user_ignore_alerts = render_array(params.ignore_alerts);
+local user_ignore_alerts = com.renderArray(params.ignore_alerts);
 
 // Upstream alerts to ignore
 local ignore_alerts = std.set(

--- a/component/alertrules.libsonnet
+++ b/component/alertrules.libsonnet
@@ -8,8 +8,9 @@ local runbook(alertname) =
   'https://hub.syn.tools/openshift4-logging/runbooks/%s.html' % alertname;
 
 assert
-  std.member(inv.applications, 'openshift4-monitoring')
-  : 'openshift4-monitoring is not available';
+  std.member(inv.applications, 'openshift4-monitoring') ||
+  std.member(inv.applications, 'prometheus')
+  : 'neither component `openshift4-monitoring` nor `prometheus` enabled';
 
 // Function to process an array which supports removing previously added
 // elements by prefixing them with ~
@@ -62,7 +63,15 @@ local patch_alerts = {
 // reuse their functionality as a black box to make sure our alerts work
 // correctly in the environment into which we're deploying.
 
-local global_alert_params = inv.parameters.openshift4_monitoring.alerts;
+// XXX: We'll figure out how we do alert management, when we start working on
+// alerting for the vendor-independent monitoring stack based on component
+// prometheus.
+local global_alert_params =
+  com.getValueOrDefault(
+    inv.parameters,
+    'openshift4_monitoring',
+    { alerts: { ignoreNames: [] } }
+  ).alerts;
 
 local filter_patch_rules(g) =
   // combine our set of alerts to ignore with the monitoring component's

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -209,6 +209,7 @@ local namespace_groups = (
 + (
   if params.monitoring.enabled then {
     '70_monitoring_namespace': metrics.namespace,
+    '70_monitoring_networkpolicy': metrics.network_policy,
     '70_monitoring_servicemonitors': metrics.service_monitors,
   } else {
   }

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -205,5 +205,11 @@ local namespace_groups = (
       },
     },
   '60_prometheus_rules': alert_rules.rules,
-  [if params.monitoring.enabled then '70_servicemonitors']: metrics.service_monitors,
 } + (import 'kibana-host.libsonnet')
++ (
+  if params.monitoring.enabled then {
+    '70_monitoring_namespace': metrics.namespace,
+    '70_monitoring_servicemonitors': metrics.service_monitors,
+  } else {
+  }
+)

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -206,11 +206,4 @@ local namespace_groups = (
     },
   '60_prometheus_rules': alert_rules.rules,
 } + (import 'kibana-host.libsonnet')
-+ (
-  if params.monitoring.enabled then {
-    '70_monitoring_namespace': metrics.namespace,
-    '70_monitoring_networkpolicy': metrics.network_policy,
-    '70_monitoring_servicemonitors': metrics.service_monitors,
-  } else {
-  }
-)
++ (import 'metrics.libsonnet')

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -10,6 +10,7 @@ local group = 'operators.coreos.com/';
 local clusterLoggingGroupVersion = 'logging.openshift.io/v1';
 
 local alert_rules = import 'alertrules.libsonnet';
+local metrics = import 'metrics.libsonnet';
 
 local namespace_groups = (
   if std.objectHas(params.clusterLogForwarding, 'namespaces') then
@@ -204,4 +205,5 @@ local namespace_groups = (
       },
     },
   '60_prometheus_rules': alert_rules.rules,
+  [if params.monitoring.enabled then '70_servicemonitors']: metrics.service_monitors,
 } + (import 'kibana-host.libsonnet')

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -10,12 +10,6 @@ local syn_metrics =
   std.member(inv.applications, 'prometheus');
 
 local nsName = 'syn-monitoring-openshift4-logging';
-local endpointDefaults = {
-  interval: '30s',
-  relabelings: [
-    prom.DropRuntimeMetrics,
-  ],
-};
 
 local promInstance =
   if params.monitoring.instance != '' then
@@ -31,7 +25,7 @@ local serviceMonitors = [
     endpoints: {
       operator: {
         interval: '30s',
-        relabelings: [
+        metricRelabelings: [
           prom.DropRuntimeMetrics,
         ],
         port: 'http-metrics',
@@ -54,7 +48,7 @@ local serviceMonitors = [
           // Fluentd doesn't need bearer token
           bearerTokenFile:: '',
           port: 'logfile-metrics',
-          relabelings: [
+          metricRelabelings: [
             prom.DropRuntimeMetrics,
           ],
         },
@@ -76,7 +70,7 @@ local serviceMonitors = [
         {
           path: '/_prometheus/metrics',
           port: 'elasticsearch',
-          relabelings: [
+          metricRelabelings: [
             prom.DropRuntimeMetrics,
           ],
         },

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -41,6 +41,17 @@ local serviceMonitors = [
         prom.ServiceMonitorHttpsEndpoint('fluentd.openshift-logging.svc') {
           // Fluentd doesn't need bearer token
           bearerTokenFile:: '',
+          metricRelabelings: [
+            {
+              // Drop high-cardinality, low-value metrics regarding the amount
+              // of logs ingested *per pod & container*.
+              action: 'drop',
+              regex:
+                '(cluster_logging_collector_input_record_(bytes|total)|' +
+                'log_collected_bytes_total)',
+              sourceLabels: [ '__name__' ],
+            },
+          ],
         },
     },
     targetNamespace: params.namespace,

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -41,10 +41,6 @@ local serviceMonitors = [
         prom.ServiceMonitorHttpsEndpoint('fluentd.openshift-logging.svc') {
           // Fluentd doesn't need bearer token
           bearerTokenFile:: '',
-          port: 'logfile-metrics',
-          metricRelabelings: [
-            prom.DropRuntimeMetrics,
-          ],
         },
     },
     targetNamespace: params.namespace,

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -1,126 +1,79 @@
-/*
-- apiVersion: monitoring.coreos.com/v1
-  kind: ServiceMonitor
-  metadata:
-    creationTimestamp: "2022-04-18T10:03:18Z"
-    generation: 1
-    labels:
-      control-plane: controller-manager
-    name: cluster-logging-operator-metrics-monitor
-    namespace: openshift-logging
-    ownerReferences:
-    - apiVersion: operators.coreos.com/v1alpha1
-      blockOwnerDeletion: false
-      controller: false
-      kind: ClusterServiceVersion
-      name: cluster-logging.5.2.11
-      uid: 836f800d-82ab-444c-9d67-1e33028a91d0
-    resourceVersion: "466758226"
-    uid: 34c85cf9-c513-42fe-aeb9-c4d59d31810e
-  spec:
-    endpoints:
-    - port: http-metrics
-    namespaceSelector: {}
-    selector:
-      matchLabels:
-        control-plane: cluster-logging-operator
-- apiVersion: monitoring.coreos.com/v1
-  kind: ServiceMonitor
-  metadata:
-    creationTimestamp: "2021-10-14T07:57:45Z"
-    generation: 1
-    name: fluentd
-    namespace: openshift-logging
-    ownerReferences:
-    - apiVersion: logging.openshift.io/v1
-      controller: true
-      kind: ClusterLogging
-      name: instance
-      uid: 4cb4fcdd-7284-4781-9ede-0b250d6a99e6
-    resourceVersion: "406788"
-    uid: f1158c9f-e5f8-4a33-bd4b-840428035887
-  spec:
-    endpoints:
-    - bearerTokenSecret:
-        key: ""
-      path: /metrics
-      port: metrics
-      scheme: https
-      tlsConfig:
-        ca: {}
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        cert: {}
-        serverName: fluentd.openshift-logging.svc
-    - bearerTokenSecret:
-        key: ""
-      path: /metrics
-      port: logfile-metrics
-      scheme: https
-      tlsConfig:
-        ca: {}
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        cert: {}
-        serverName: fluentd.openshift-logging.svc
-    jobLabel: monitor-fluentd
-    namespaceSelector:
-      matchNames:
-      - openshift-logging
-    selector:
-      matchLabels:
-        logging-infra: support
-- apiVersion: monitoring.coreos.com/v1
-  kind: ServiceMonitor
-  metadata:
-    creationTimestamp: "2021-10-14T07:58:18Z"
-    generation: 1
-    labels:
-      cluster-name: elasticsearch
-      scrape-metrics: enabled
-    name: monitor-elasticsearch-cluster
-    namespace: openshift-logging
-    ownerReferences:
-    - apiVersion: logging.openshift.io/v1
-      controller: true
-      kind: Elasticsearch
-      name: elasticsearch
-      uid: 34fc08a0-d069-4a78-8ae7-71ae915513df
-    resourceVersion: "73826551"
-    uid: c3a18817-425a-410c-9789-6ecec603172e
-  spec:
-    endpoints:
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      bearerTokenSecret:
-        key: ""
-      path: /metrics
-      port: elasticsearch
-      scheme: https
-      tlsConfig:
-        ca: {}
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        cert: {}
-        serverName: elasticsearch-metrics.openshift-logging.svc
-    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-      bearerTokenSecret:
-        key: ""
-      path: /_prometheus/metrics
-      port: elasticsearch
-      scheme: https
-      tlsConfig:
-        ca: {}
-        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-        cert: {}
-        serverName: elasticsearch-metrics.openshift-logging.svc
-    jobLabel: monitor-elasticsearch
-    namespaceSelector:
-      matchNames:
-      - openshift-logging
-    selector:
-      matchLabels:
-        cluster-name: elasticsearch
-        scrape-metrics: enabled
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local prom = import 'lib/prometheus.libsonnet';
 
-*/
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_logging;
+
+local endpointDefaults = {
+  interval: '30s',
+  relabelings: [
+    prom.DropRuntimeMetrics,
+  ],
+};
+
+local serviceMonitors = [
+  prom.ServiceMonitor('cluster-logging-operator') {
+    endpoints: {
+      operator: {
+        interval: '30s',
+        relabelings: [
+          prom.DropRuntimeMetrics,
+        ],
+        port: 'http-metrics',
+      },
+    },
+    selector: {
+      matchLabels: {
+        'control-plane': 'cluster-logging-operator',
+      },
+    },
+    targetNamespace: params.namespace,
+  },
+  prom.ServiceMonitor('fluentd') {
+    endpoints: {
+      fluentd:
+        prom.ServiceMonitorHttpsEndpoint('fluentd.openshift-logging.svc') {
+          // Fluentd doesn't need bearer token
+          bearerTokenFile:: '',
+          port: 'logfile-metrics',
+          relabelings: [
+            prom.DropRuntimeMetrics,
+          ],
+        },
+    },
+    targetNamespace: params.namespace,
+    selector: {
+      matchLabels: {
+        'logging-infra': 'support',
+      },
+    },
+  },
+  prom.ServiceMonitor('elasticsearch-cluster') {
+    endpoints: {
+      elasticsearch:
+        prom.ServiceMonitorHttpsEndpoint('elasticsearch-metrics.openshift-logging.svc')
+        {
+          path: '/_prometheus/metrics',
+          port: 'elasticsearch',
+          relabelings: [
+            prom.DropRuntimeMetrics,
+          ],
+        },
+    },
+    targetNamespace: params.namespace,
+    selector: {
+      matchLabels: {
+        'cluster-name': 'elasticsearch',
+        'scrape-metrics': 'enabled',
+      },
+    },
+  },
+];
 
 {
-  service_monitors: [],
+  namespace: prom.RegisterNamespace(
+    kube.Namespace('syn-monitoring-openshift4-logging')
+  ),
+  service_monitors: serviceMonitors,
 }

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -1,0 +1,126 @@
+/*
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    creationTimestamp: "2022-04-18T10:03:18Z"
+    generation: 1
+    labels:
+      control-plane: controller-manager
+    name: cluster-logging-operator-metrics-monitor
+    namespace: openshift-logging
+    ownerReferences:
+    - apiVersion: operators.coreos.com/v1alpha1
+      blockOwnerDeletion: false
+      controller: false
+      kind: ClusterServiceVersion
+      name: cluster-logging.5.2.11
+      uid: 836f800d-82ab-444c-9d67-1e33028a91d0
+    resourceVersion: "466758226"
+    uid: 34c85cf9-c513-42fe-aeb9-c4d59d31810e
+  spec:
+    endpoints:
+    - port: http-metrics
+    namespaceSelector: {}
+    selector:
+      matchLabels:
+        control-plane: cluster-logging-operator
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    creationTimestamp: "2021-10-14T07:57:45Z"
+    generation: 1
+    name: fluentd
+    namespace: openshift-logging
+    ownerReferences:
+    - apiVersion: logging.openshift.io/v1
+      controller: true
+      kind: ClusterLogging
+      name: instance
+      uid: 4cb4fcdd-7284-4781-9ede-0b250d6a99e6
+    resourceVersion: "406788"
+    uid: f1158c9f-e5f8-4a33-bd4b-840428035887
+  spec:
+    endpoints:
+    - bearerTokenSecret:
+        key: ""
+      path: /metrics
+      port: metrics
+      scheme: https
+      tlsConfig:
+        ca: {}
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        cert: {}
+        serverName: fluentd.openshift-logging.svc
+    - bearerTokenSecret:
+        key: ""
+      path: /metrics
+      port: logfile-metrics
+      scheme: https
+      tlsConfig:
+        ca: {}
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        cert: {}
+        serverName: fluentd.openshift-logging.svc
+    jobLabel: monitor-fluentd
+    namespaceSelector:
+      matchNames:
+      - openshift-logging
+    selector:
+      matchLabels:
+        logging-infra: support
+- apiVersion: monitoring.coreos.com/v1
+  kind: ServiceMonitor
+  metadata:
+    creationTimestamp: "2021-10-14T07:58:18Z"
+    generation: 1
+    labels:
+      cluster-name: elasticsearch
+      scrape-metrics: enabled
+    name: monitor-elasticsearch-cluster
+    namespace: openshift-logging
+    ownerReferences:
+    - apiVersion: logging.openshift.io/v1
+      controller: true
+      kind: Elasticsearch
+      name: elasticsearch
+      uid: 34fc08a0-d069-4a78-8ae7-71ae915513df
+    resourceVersion: "73826551"
+    uid: c3a18817-425a-410c-9789-6ecec603172e
+  spec:
+    endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        key: ""
+      path: /metrics
+      port: elasticsearch
+      scheme: https
+      tlsConfig:
+        ca: {}
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        cert: {}
+        serverName: elasticsearch-metrics.openshift-logging.svc
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      bearerTokenSecret:
+        key: ""
+      path: /_prometheus/metrics
+      port: elasticsearch
+      scheme: https
+      tlsConfig:
+        ca: {}
+        caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+        cert: {}
+        serverName: elasticsearch-metrics.openshift-logging.svc
+    jobLabel: monitor-elasticsearch
+    namespaceSelector:
+      matchNames:
+      - openshift-logging
+    selector:
+      matchLabels:
+        cluster-name: elasticsearch
+        scrape-metrics: enabled
+
+*/
+
+{
+  service_monitors: [],
+}

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -103,4 +103,8 @@ if syn_metrics then
     },
   }
 else
-  {}
+  std.trace(
+    'Monitoring disabled or component `prometheus` not present, '
+    + 'not deploying ServiceMonitors',
+    {}
+  )

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -12,6 +12,12 @@ local endpointDefaults = {
   ],
 };
 
+local promInstance =
+  if params.monitoring.instance != '' then
+    params.monitoring.instance
+  else
+    inv.parameters.prometheus.defaultInstance;
+
 local serviceMonitors = [
   prom.ServiceMonitor('cluster-logging-operator') {
     endpoints: {
@@ -73,7 +79,8 @@ local serviceMonitors = [
 
 {
   namespace: prom.RegisterNamespace(
-    kube.Namespace('syn-monitoring-openshift4-logging')
+    kube.Namespace('syn-monitoring-openshift4-logging'),
+    instance=promInstance,
   ),
   service_monitors: serviceMonitors,
 }

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -93,4 +93,11 @@ local serviceMonitors = [
     instance=promInstance,
   ),
   service_monitors: serviceMonitors,
+  network_policy: prom.NetworkPolicy(instance=promInstance) {
+    metadata+: {
+      // The networkpolicy needs to be in the namespace in which OpenShift
+      // logging is deployed.
+      namespace: params.namespace,
+    },
+  },
 }

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -12,7 +12,7 @@ local syn_metrics =
 local nsName = 'syn-monitoring-openshift4-logging';
 
 local promInstance =
-  if params.monitoring.instance != '' then
+  if params.monitoring.instance != null then
     params.monitoring.instance
   else
     inv.parameters.prometheus.defaultInstance;

--- a/component/metrics.libsonnet
+++ b/component/metrics.libsonnet
@@ -5,6 +5,7 @@ local prom = import 'lib/prometheus.libsonnet';
 local inv = kap.inventory();
 local params = inv.parameters.openshift4_logging;
 
+local nsName = 'syn-monitoring-openshift4-logging';
 local endpointDefaults = {
   interval: '30s',
   relabelings: [
@@ -19,7 +20,10 @@ local promInstance =
     inv.parameters.prometheus.defaultInstance;
 
 local serviceMonitors = [
-  prom.ServiceMonitor('cluster-logging-operator') {
+  prom.ServiceMonitor('cluster-logging-operator',) {
+    metadata+: {
+      namespace: nsName,
+    },
     endpoints: {
       operator: {
         interval: '30s',
@@ -37,6 +41,9 @@ local serviceMonitors = [
     targetNamespace: params.namespace,
   },
   prom.ServiceMonitor('fluentd') {
+    metadata+: {
+      namespace: nsName,
+    },
     endpoints: {
       fluentd:
         prom.ServiceMonitorHttpsEndpoint('fluentd.openshift-logging.svc') {
@@ -56,6 +63,9 @@ local serviceMonitors = [
     },
   },
   prom.ServiceMonitor('elasticsearch-cluster') {
+    metadata+: {
+      namespace: nsName,
+    },
     endpoints: {
       elasticsearch:
         prom.ServiceMonitorHttpsEndpoint('elasticsearch-metrics.openshift-logging.svc')
@@ -79,7 +89,7 @@ local serviceMonitors = [
 
 {
   namespace: prom.RegisterNamespace(
-    kube.Namespace('syn-monitoring-openshift4-logging'),
+    kube.Namespace(nsName),
     instance=promInstance,
   ),
   service_monitors: serviceMonitors,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -128,6 +128,40 @@ default:: []
 This parameter can be used to disable alerts provided by openshift cluster-logging-operator.
 The component supports removing entries in this parameter by providing the entry prefixed with `~`.
 
+== `monitoring`
+
+This parameter allows users to enable the component's monitoring configuration.
+Currently the component has support for deploying custom `ServiceMonitors` on clusters which use component `prometheus` to manage a custom monitoring stack.
+
+=== `enabled`
+
+[horizontal]
+type:: boolean
+default:: `true`
+
+Whether to deploy monitoring configurations.
+If this parameter is set to `true`, the component will check whether component `prometheus` is present on the cluster.
+If the component is missing, no configurations will be deployed regardless of the value of this parameter.
+
+=== `instance`
+
+[horizontal]
+type:: string
+default:: `null`
+
+This parameter can be used to indicate which custom Prometheus instance should pick up the configurations managed by the component.
+
+If the parameter is set to `null`, the default instance configured for component `prometheus` will be used.
+
+=== `enableServiceMonitors`
+
+[horizontal]
+type:: dictionary
+default:: https://github.com/appuio/component-openshift4-logging/blob/master/class/defaults.yml[See `class/defaults.yml`]
+
+A dictionary with the names of service monitors as keys and booleans as the value.
+Can be used to selectively enable or disable service monitors.
+
 == `clusterLogging`
 
 [horizontal]

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_namespace.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations: {}
+  labels:
+    monitoring.syn.tools/monitoring: 'true'
+    name: syn-monitoring-openshift4-logging
+  name: syn-monitoring-openshift4-logging

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_networkpolicy.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_networkpolicy.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-from-prometheus-monitoring
+  name: allow-from-prometheus-monitoring
+  namespace: openshift-logging
+spec:
+  egress: []
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: syn-monitoring
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
@@ -9,12 +9,12 @@ metadata:
 spec:
   endpoints:
     - interval: 30s
-      port: http-metrics
-      relabelings:
+      metricRelabelings:
         - action: drop
           regex: (go_.*|process_.*|promhttp_.*)
           sourceLabels:
             - __name__
+      port: http-metrics
   namespaceSelector:
     matchNames:
       - openshift-logging
@@ -33,12 +33,12 @@ metadata:
 spec:
   endpoints:
     - interval: 30s
-      port: logfile-metrics
-      relabelings:
+      metricRelabelings:
         - action: drop
           regex: (go_.*|process_.*|promhttp_.*)
           sourceLabels:
             - __name__
+      port: logfile-metrics
       scheme: https
       tlsConfig:
         caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
@@ -62,13 +62,13 @@ spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
       interval: 30s
-      path: /_prometheus/metrics
-      port: elasticsearch
-      relabelings:
+      metricRelabelings:
         - action: drop
           regex: (go_.*|process_.*|promhttp_.*)
           sourceLabels:
             - __name__
+      path: /_prometheus/metrics
+      port: elasticsearch
       scheme: https
       tlsConfig:
         caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
@@ -33,12 +33,7 @@ metadata:
 spec:
   endpoints:
     - interval: 30s
-      metricRelabelings:
-        - action: drop
-          regex: (go_.*|process_.*|promhttp_.*)
-          sourceLabels:
-            - __name__
-      port: logfile-metrics
+      port: metrics
       scheme: https
       tlsConfig:
         caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
@@ -5,6 +5,7 @@ metadata:
   labels:
     name: cluster-logging-operator
   name: cluster-logging-operator
+  namespace: syn-monitoring-openshift4-logging
 spec:
   endpoints:
     - interval: 30s
@@ -28,6 +29,7 @@ metadata:
   labels:
     name: fluentd
   name: fluentd
+  namespace: syn-monitoring-openshift4-logging
 spec:
   endpoints:
     - interval: 30s
@@ -55,6 +57,7 @@ metadata:
   labels:
     name: elasticsearch-cluster
   name: elasticsearch-cluster
+  namespace: syn-monitoring-openshift4-logging
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
@@ -33,6 +33,11 @@ metadata:
 spec:
   endpoints:
     - interval: 30s
+      metricRelabelings:
+        - action: drop
+          regex: (cluster_logging_collector_input_record_(bytes|total)|log_collected_bytes_total)
+          sourceLabels:
+            - __name__
       port: metrics
       scheme: https
       tlsConfig:

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/70_monitoring_servicemonitors.yaml
@@ -1,0 +1,79 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging-operator
+  name: cluster-logging-operator
+spec:
+  endpoints:
+    - interval: 30s
+      port: http-metrics
+      relabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+  namespaceSelector:
+    matchNames:
+      - openshift-logging
+  selector:
+    matchLabels:
+      control-plane: cluster-logging-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: fluentd
+  name: fluentd
+spec:
+  endpoints:
+    - interval: 30s
+      port: logfile-metrics
+      relabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: fluentd.openshift-logging.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-logging
+  selector:
+    matchLabels:
+      logging-infra: support
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  annotations: {}
+  labels:
+    name: elasticsearch-cluster
+  name: elasticsearch-cluster
+spec:
+  endpoints:
+    - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      interval: 30s
+      path: /_prometheus/metrics
+      port: elasticsearch
+      relabelings:
+        - action: drop
+          regex: (go_.*|process_.*|promhttp_.*)
+          sourceLabels:
+            - __name__
+      scheme: https
+      tlsConfig:
+        caFile: /var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt
+        serverName: elasticsearch-metrics.openshift-logging.svc
+  namespaceSelector:
+    matchNames:
+      - openshift-logging
+  selector:
+    matchLabels:
+      cluster-name: elasticsearch
+      scrape-metrics: enabled

--- a/tests/syn-monitoring.yml
+++ b/tests/syn-monitoring.yml
@@ -1,8 +1,5 @@
 applications:
   - openshift4-operators as openshift-operators-redhat
-  # TODO: remove this application once we update the component to support the
-  # new monitoring stack.
-  - openshift4-monitoring
   - prometheus
 
 parameters:
@@ -30,7 +27,3 @@ parameters:
           namespace: syn-monitoring
         prometheus:
           enabled: true
-
-  openshift4_monitoring:
-    alerts:
-      ignoreNames: []

--- a/tests/syn-monitoring.yml
+++ b/tests/syn-monitoring.yml
@@ -11,6 +11,10 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/v1.0.2/lib/openshift4-operators.libsonnet
         output_path: vendor/lib/openshift4-operators.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
+        output_path: vendor/lib/prometheus.libsonnet
+
 
   openshift4_operators:
     defaultInstallPlanApproval: Automatic

--- a/tests/syn-monitoring.yml
+++ b/tests/syn-monitoring.yml
@@ -30,7 +30,3 @@ parameters:
   openshift4_monitoring:
     alerts:
       ignoreNames: []
-
-  openshift4_logging:
-    monitoring:
-      enabled: true


### PR DESCRIPTION
Configure ServiceMonitors to scrape Elasticsearch, fluentd and logging-operator metrics in the vendor-independent monitoring stack.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
