### PR TITLE
Inject `spec.collection.type` for cluster-logging channels >= `release-5.5`

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,13 @@
 {
   "template": "https://github.com/projectsyn/commodore-component-template.git",
-  "commit": "0f8aa8baef803c2f09d710c717f26f7eff145407",
+  "commit": "86f54285090cc7ef5372a32b752f8bcdc562b338",
   "checkout": "main",
   "context": {
     "cookiecutter": {
       "name": "OpenShift4 Logging",
       "slug": "openshift4-logging",
       "parameter_key": "openshift4_logging",
-      "test_cases": "defaults syn-monitoring",
+      "test_cases": "defaults syn-monitoring release-5.4 release-5.5",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,8 @@ jobs:
         instance:
           - defaults
           - syn-monitoring
+          - release-5.4
+          - release-5.5
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -50,6 +52,8 @@ jobs:
         instance:
           - defaults
           - syn-monitoring
+          - release-5.4
+          - release-5.5
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/syn-monitoring.yml
+test_instances = tests/defaults.yml tests/syn-monitoring.yml tests/release-5.4.yml tests/release-5.5.yml

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -27,6 +27,18 @@ Choosing the stable channel allows never have to care about the interoperability
 
 See the https://docs.openshift.com/container-platform/latest/logging/cluster-logging-deploying.html#cluster-logging-deploy-cli_cluster-logging-deploying[OpenShift documentation] for details.
 
+[TIP]
+====
+Due to different required default configurations for the `clusterlogging` custom resource between logging stack versions <= 5.4 and >= 5.5, the component will attempt to parse the logging stack version from the value of this parameter.
+
+The parser can parse the version from channels with arbitrary channel names, as long as the channel adheres to the format `<channel>-<major>.<minor>`.
+If parsing fails for any reason, the parser will err on the side of the version being >= 5.5.
+Potential parsing failures are that the version can't be extracted from the channel, or that the major or minor version can't be converted to a number.
+If there's a parsing failure, the component will print a diagnostic message indicating where the parsing failed.
+
+To ensure that the component renders a configuration which works properly, we recommend that users set the channel to a `stable-5.x` version.
+====
+
 == `alerts`
 
 [horizontal]

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
@@ -12,6 +12,7 @@ spec:
     logs:
       fluentd: {}
       type: fluentd
+    type: fluentd
   curation:
     curator:
       nodeSelector:

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/00_namespace.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/00_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: openshift-logging
+    openshift.io/cluster-monitoring: 'true'
+  name: openshift-logging

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/10_operator_group.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/10_operator_group.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  targetNamespaces:
+    - openshift-logging

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -1,0 +1,29 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: elasticsearch-operator
+  name: elasticsearch-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: stable-5.4
+  installPlanApproval: Automatic
+  name: elasticsearch-operator
+  source: openshift-operators-redhat
+  sourceNamespace: openshift-operators-redhat
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: stable-5.4
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-operators-redhat

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
@@ -1,0 +1,43 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: instance
+  name: instance
+  namespace: openshift-logging
+spec:
+  collection:
+    logs:
+      fluentd: {}
+      type: fluentd
+  curation:
+    curator:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      schedule: 30 3 * * *
+    type: curator
+  logStore:
+    elasticsearch:
+      nodeCount: 3
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      redundancyPolicy: SingleRedundancy
+      storage:
+        size: 200Gi
+    retentionPolicy:
+      application:
+        maxAge: 7d
+      audit:
+        maxAge: 30d
+      infra:
+        maxAge: 30d
+    type: elasticsearch
+  managementState: Managed
+  visualization:
+    kibana:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    type: kibana

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/40_journald_configs.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/40_journald_configs.yaml
@@ -1,0 +1,39 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations: {}
+  labels:
+    machineconfiguration.openshift.io/role: master
+    name: 40-master-journald
+  name: 40-master-journald
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,TWF4UmV0ZW50aW9uU2VjPTFtb250aApSYXRlTGltaXRCdXJzdD0xMDAwMApSYXRlTGltaXRJbnRlcnZhbD0xcwpTdG9yYWdlPXBlcnNpc3RlbnQKU3luY0ludGVydmFsU2VjPTFzCg==
+          filesystem: root
+          mode: 420
+          path: /etc/systemd/journald.conf
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations: {}
+  labels:
+    machineconfiguration.openshift.io/role: worker
+    name: 40-worker-journald
+  name: 40-worker-journald
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,TWF4UmV0ZW50aW9uU2VjPTFtb250aApSYXRlTGltaXRCdXJzdD0xMDAwMApSYXRlTGltaXRJbnRlcnZhbD0xcwpTdG9yYWdlPXBlcnNpc3RlbnQKU3luY0ludGVydmFsU2VjPTFzCg==
+          filesystem: root
+          mode: 420
+          path: /etc/systemd/journald.conf

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/50_networkpolicy.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/50_networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-from-openshift-operators-redhat
+  name: allow-from-openshift-operators-redhat
+  namespace: openshift-logging
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: openshift-operators-redhat
+        - podSelector:
+            matchLabels:
+              name: elasticsearch-operator
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
@@ -1,0 +1,84 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: syn-logging-rules
+  name: syn-logging-rules
+  namespace: openshift-logging
+spec:
+  groups:
+    - name: logging_fluentd.alerts
+      rules:
+        - alert: SYN_FluentdNodeDown
+          annotations:
+            message: Prometheus could not scrape fluentd {{ $labels.instance }} for
+              more than 10m.
+            summary: Fluentd cannot be scraped
+          expr: 'up{job="collector"} == 0 or absent(up{job="collector"}) == 1
+
+            '
+          for: 10m
+          labels:
+            service: fluentd
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentdQueueLengthIncreasing
+          annotations:
+            message: For the last hour, fluentd {{ $labels.instance }} output '{{
+              $labels.plugin_id }}' average buffer queue length has increased continuously.
+            summary: Fluentd is unable to keep up with traffic over time for forwarder
+              output {{ $labels.plugin_id }}.
+          expr: '( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  +
+            on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
+            > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
+
+            '
+          for: 12h
+          labels:
+            service: fluentd
+            severity: Warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentDHighErrorRate
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by fluentd
+              {{ $labels.instance }}.'
+            summary: FluentD output errors are high
+          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+            ) > 10\n"
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentDVeryHighErrorRate
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by fluentd
+              {{ $labels.instance }}.'
+            summary: FluentD output errors are very high
+          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+            ) > 25\n"
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+    - name: elasticsearch_node_storage.alerts
+      rules:
+        - alert: SYN_ElasticsearchExpectNodeToReachDiskWatermark
+          annotations:
+            message: Expecting to reach disk low watermark at {{ $labels.node }} node
+              in {{ $labels.cluster }} cluster in 72 hours. When reaching the watermark
+              no new shards will be allocated to this node anymore. You should consider
+              adding more disk to the node.
+            runbook_url: https://hub.syn.tools/openshift4-logging/runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.html
+            summary: Expecting to Reach Disk Low Watermark in 72 Hours
+          expr: "sum by(cluster, instance, node) (\n  (1 - (predict_linear(es_fs_path_available_bytes[72h],\
+            \ 259200) / es_fs_path_total_bytes)) * 100\n) > 85\n"
+          for: 6h
+          labels:
+            severity: warning

--- a/tests/golden/release-5.5/openshift4-logging/openshift4-logging/00_namespace.yaml
+++ b/tests/golden/release-5.5/openshift4-logging/openshift4-logging/00_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: openshift-logging
+    openshift.io/cluster-monitoring: 'true'
+  name: openshift-logging

--- a/tests/golden/release-5.5/openshift4-logging/openshift4-logging/10_operator_group.yaml
+++ b/tests/golden/release-5.5/openshift4-logging/openshift4-logging/10_operator_group.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  targetNamespaces:
+    - openshift-logging

--- a/tests/golden/release-5.5/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/release-5.5/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -1,0 +1,29 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: elasticsearch-operator
+  name: elasticsearch-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: stable-5.5
+  installPlanApproval: Automatic
+  name: elasticsearch-operator
+  source: openshift-operators-redhat
+  sourceNamespace: openshift-operators-redhat
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: stable-5.5
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-operators-redhat

--- a/tests/golden/release-5.5/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
+++ b/tests/golden/release-5.5/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
@@ -12,6 +12,7 @@ spec:
     logs:
       fluentd: {}
       type: fluentd
+    type: fluentd
   curation:
     curator:
       nodeSelector:

--- a/tests/golden/release-5.5/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
+++ b/tests/golden/release-5.5/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
@@ -1,0 +1,43 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: instance
+  name: instance
+  namespace: openshift-logging
+spec:
+  collection:
+    logs:
+      fluentd: {}
+      type: fluentd
+  curation:
+    curator:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      schedule: 30 3 * * *
+    type: curator
+  logStore:
+    elasticsearch:
+      nodeCount: 3
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      redundancyPolicy: SingleRedundancy
+      storage:
+        size: 200Gi
+    retentionPolicy:
+      application:
+        maxAge: 7d
+      audit:
+        maxAge: 30d
+      infra:
+        maxAge: 30d
+    type: elasticsearch
+  managementState: Managed
+  visualization:
+    kibana:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    type: kibana

--- a/tests/golden/release-5.5/openshift4-logging/openshift4-logging/40_journald_configs.yaml
+++ b/tests/golden/release-5.5/openshift4-logging/openshift4-logging/40_journald_configs.yaml
@@ -1,0 +1,39 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations: {}
+  labels:
+    machineconfiguration.openshift.io/role: master
+    name: 40-master-journald
+  name: 40-master-journald
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,TWF4UmV0ZW50aW9uU2VjPTFtb250aApSYXRlTGltaXRCdXJzdD0xMDAwMApSYXRlTGltaXRJbnRlcnZhbD0xcwpTdG9yYWdlPXBlcnNpc3RlbnQKU3luY0ludGVydmFsU2VjPTFzCg==
+          filesystem: root
+          mode: 420
+          path: /etc/systemd/journald.conf
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations: {}
+  labels:
+    machineconfiguration.openshift.io/role: worker
+    name: 40-worker-journald
+  name: 40-worker-journald
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,TWF4UmV0ZW50aW9uU2VjPTFtb250aApSYXRlTGltaXRCdXJzdD0xMDAwMApSYXRlTGltaXRJbnRlcnZhbD0xcwpTdG9yYWdlPXBlcnNpc3RlbnQKU3luY0ludGVydmFsU2VjPTFzCg==
+          filesystem: root
+          mode: 420
+          path: /etc/systemd/journald.conf

--- a/tests/golden/release-5.5/openshift4-logging/openshift4-logging/50_networkpolicy.yaml
+++ b/tests/golden/release-5.5/openshift4-logging/openshift4-logging/50_networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-from-openshift-operators-redhat
+  name: allow-from-openshift-operators-redhat
+  namespace: openshift-logging
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: openshift-operators-redhat
+        - podSelector:
+            matchLabels:
+              name: elasticsearch-operator
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/tests/golden/release-5.5/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
+++ b/tests/golden/release-5.5/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
@@ -1,0 +1,84 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: syn-logging-rules
+  name: syn-logging-rules
+  namespace: openshift-logging
+spec:
+  groups:
+    - name: logging_fluentd.alerts
+      rules:
+        - alert: SYN_FluentdNodeDown
+          annotations:
+            message: Prometheus could not scrape fluentd {{ $labels.instance }} for
+              more than 10m.
+            summary: Fluentd cannot be scraped
+          expr: 'up{job="collector"} == 0 or absent(up{job="collector"}) == 1
+
+            '
+          for: 10m
+          labels:
+            service: fluentd
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentdQueueLengthIncreasing
+          annotations:
+            message: For the last hour, fluentd {{ $labels.instance }} output '{{
+              $labels.plugin_id }}' average buffer queue length has increased continuously.
+            summary: Fluentd is unable to keep up with traffic over time for forwarder
+              output {{ $labels.plugin_id }}.
+          expr: '( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  +
+            on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
+            > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
+
+            '
+          for: 12h
+          labels:
+            service: fluentd
+            severity: Warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentDHighErrorRate
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by fluentd
+              {{ $labels.instance }}.'
+            summary: FluentD output errors are high
+          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+            ) > 10\n"
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentDVeryHighErrorRate
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by fluentd
+              {{ $labels.instance }}.'
+            summary: FluentD output errors are very high
+          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+            ) > 25\n"
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+    - name: elasticsearch_node_storage.alerts
+      rules:
+        - alert: SYN_ElasticsearchExpectNodeToReachDiskWatermark
+          annotations:
+            message: Expecting to reach disk low watermark at {{ $labels.node }} node
+              in {{ $labels.cluster }} cluster in 72 hours. When reaching the watermark
+              no new shards will be allocated to this node anymore. You should consider
+              adding more disk to the node.
+            runbook_url: https://hub.syn.tools/openshift4-logging/runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.html
+            summary: Expecting to Reach Disk Low Watermark in 72 Hours
+          expr: "sum by(cluster, instance, node) (\n  (1 - (predict_linear(es_fs_path_available_bytes[72h],\
+            \ 259200) / es_fs_path_total_bytes)) * 100\n) > 85\n"
+          for: 6h
+          labels:
+            severity: warning

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
@@ -12,6 +12,7 @@ spec:
     logs:
       fluentd: {}
       type: fluentd
+    type: fluentd
   curation:
     curator:
       nodeSelector:

--- a/tests/release-5.4.yml
+++ b/tests/release-5.4.yml
@@ -1,0 +1,22 @@
+applications:
+  - openshift4-operators as openshift-operators-redhat
+  - openshift4-monitoring
+
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/v1.0.2/lib/openshift4-operators.libsonnet
+        output_path: vendor/lib/openshift4-operators.libsonnet
+
+  openshift4_operators:
+    defaultInstallPlanApproval: Automatic
+    defaultSource: openshift-operators-redhat
+    defaultSourceNamespace: openshift-operators-redhat
+
+  openshift4_monitoring:
+    alerts:
+      ignoreNames: []
+
+  openshift4_logging:
+    channel: stable-5.4

--- a/tests/release-5.5.yml
+++ b/tests/release-5.5.yml
@@ -1,0 +1,22 @@
+applications:
+  - openshift4-operators as openshift-operators-redhat
+  - openshift4-monitoring
+
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/v1.0.2/lib/openshift4-operators.libsonnet
+        output_path: vendor/lib/openshift4-operators.libsonnet
+
+  openshift4_operators:
+    defaultInstallPlanApproval: Automatic
+    defaultSource: openshift-operators-redhat
+    defaultSourceNamespace: openshift-operators-redhat
+
+  openshift4_monitoring:
+    alerts:
+      ignoreNames: []
+
+  openshift4_logging:
+    channel: stable-5.5


### PR DESCRIPTION
We add some logic to parse the provided channel to determine whether we're on a 5.5+ channel. The parsing logic supports arbitrary channel names but expects the format to be `<channel>-<major>.<minor>`. If parsing fails, the logic prints a warning and assumes that the channel is >= 5.5.

We need to make sure we only add the field `spec.collector.type` if we're on at least 5.5, because earlier versions of the cluster-logging operator will remove the field `spec.collection.type` from the CR which will cause a loop between ArgoCD adding the field and the operator removing it.

On 5.5+, the configuration is required to stop the collector pods from constantly restarting, cf. https://access.redhat.com/solutions/6976455

Fixes #68

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
