### PR TITLE
Expose cluster-logging version in parameter `version`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -1,9 +1,9 @@
 parameters:
   openshift4_logging:
     namespace: openshift-logging
-    channel: 'stable'
-    # renovate: repo=https://github.com/openshift/cluster-logging-operator.git ref=master
-    alerts: '5dd49ff848203fb888a1bbb76912db92ca71f275'
+    version: '5.4'
+    channel: 'stable-${openshift4_logging:version}'
+    alerts: 'release-${openshift4_logging:version}'
     kibana_host: null
     predict_elasticsearch_storage_alert:
       enabled: true

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -26,6 +26,9 @@ This parameter is used in the default values for parameters `channel` and `alert
 We recommend that you use this parameter to specify the logging stack version which the component should deploy.
 However, you can still parameters `channel` and `alerts` directly.
 
+See the https://access.redhat.com/support/policy/updates/openshift#logging[OpenShift Logging life cycle documentation] for supported versions of the logging stack.
+We recommend that you select a version of the logging stack that's officially listed as compatible with your OpenShift version.
+
 == `channel`
 
 [horizontal]

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -14,16 +14,33 @@ default:: `openshift-logging`
 The namespace in which to install the operator.
 
 
+== `version`
+
+[horizontal]
+type:: string
+default:: `5.4`
+
+The logging stack version to deploy.
+This parameter is used in the default values for parameters `channel` and `alerts`.
+
+We recommend that you use this parameter to specify the logging stack version which the component should deploy.
+However, you can still parameters `channel` and `alerts` directly.
+
 == `channel`
 
 [horizontal]
 type:: string
-default:: `stable`
+default:: `stable-${openshift4_logging:version}`
 
 Channel of the operator subscription to use.
-In OpenShift 4.7 Red Hat introduced an OpenShift version independent logging stack starting with the version 5.0.
-Since version 5.1 there are two channels stable and stable-5.x.
-Choosing the stable channel allows never have to care about the interoperability as the specific OpenShift version delivers the right version via the operator marketplace.
+If you specify the logging stack version through parameter `version`, you shouldn't need to modify this parameter.
+
+In OpenShift 4.7, RedHat decoupled the logging stack version from the OpenShift version.
+The decoupled logging stack versions start at version 5.0.
+With version 5.1 of the logging stack, channels for specific minor versions were introduced.
+
+Ideally we would just default to the `stable` channel, as that channel will always be backed by a logging stack version compatible with the OpenShift cluster version by the OpenShift marketplace operator.
+However, since there's potential for changes in configuration between logging stack versions which need to be managed through the component, we default to using the `stable-5.x` channel matching the version specified in parameter `version`.
 
 See the https://docs.openshift.com/container-platform/latest/logging/cluster-logging-deploying.html#cluster-logging-deploy-cli_cluster-logging-deploying[OpenShift documentation] for details.
 
@@ -31,10 +48,12 @@ See the https://docs.openshift.com/container-platform/latest/logging/cluster-log
 
 [horizontal]
 type:: string
-default:: `master`
+default:: `release-${openshift4_logging:version}`
 
 Release version of the alerting rules.
-Should be adjusted according to the channel: If you specify `channel: stable-5.2` use `alerts: release-5.2`.
+If you specify the logging stack version through parameter `version`, you shouldn't need to modify this parameter.
+
+Generally, the value for parameter `alerts` should match the value for parameter `channel`: if you specify `channel: stable-5.4`, you should use `alerts: release-5.4`.
 
 == `kibana_host`
 

--- a/renovate.json
+++ b/renovate.json
@@ -14,15 +14,5 @@
   "suppressNotifications": [ "artifactErrors" ],
   "labels": [
     "dependency"
-  ],
-  "regexManagers": [
-    {
-      "fileMatch": ["^class/defaults.yml$"],
-      "matchStrings": [
-          "\n\\s*# renovate: repo=(?<packageName>.*?) ref=(?<currentValue>.*?)\n\\s*(?<depName>alerts): '(?<currentDigest>.*?)'"
-      ],
-      "versioningTemplate": "git",
-      "datasourceTemplate": "git-refs"
-    }
   ]
 }

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -7,7 +7,7 @@ metadata:
   name: elasticsearch-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable
+  channel: stable-5.4
   installPlanApproval: Automatic
   name: elasticsearch-operator
   source: openshift-operators-redhat
@@ -22,7 +22,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable
+  channel: stable-5.4
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
@@ -26,12 +26,12 @@ spec:
             syn_component: openshift4-logging
         - alert: SYN_FluentdQueueLengthIncreasing
           annotations:
-            message: For the last hour, fluentd {{ $labels.instance }} output '{{
-              $labels.plugin_id }}' average buffer queue length has increased continuously.
-            summary: Fluentd is unable to keep up with traffic over time for forwarder
-              output {{ $labels.plugin_id }}.
-          expr: '( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  +
-            on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
+            message: For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id
+              }}' average buffer queue length has increased continuously.
+            summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
+              over time for forwarder output {{ $labels.plugin_id }}.
+          expr: 'sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m]
+            offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
             > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
 
             '

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -7,7 +7,7 @@ metadata:
   name: elasticsearch-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable
+  channel: stable-5.4
   installPlanApproval: Automatic
   name: elasticsearch-operator
   source: openshift-operators-redhat
@@ -22,7 +22,7 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging
 spec:
-  channel: stable
+  channel: stable-5.4
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators

--- a/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
+++ b/tests/golden/syn-monitoring/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
@@ -26,12 +26,12 @@ spec:
             syn_component: openshift4-logging
         - alert: SYN_FluentdQueueLengthIncreasing
           annotations:
-            message: For the last hour, fluentd {{ $labels.instance }} output '{{
-              $labels.plugin_id }}' average buffer queue length has increased continuously.
-            summary: Fluentd is unable to keep up with traffic over time for forwarder
-              output {{ $labels.plugin_id }}.
-          expr: '( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  +
-            on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
+            message: For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id
+              }}' average buffer queue length has increased continuously.
+            summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
+              over time for forwarder output {{ $labels.plugin_id }}.
+          expr: 'sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m]
+            offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
             > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
 
             '


### PR DESCRIPTION
We introduce a new parameter `version` which is used to define default values for parameters `channel` and `alerts`. This change is backwards-compatible, as users can still override parameters `channel` and `alerts`.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
