### PR TITLE
Use `alert-patching.libsonnet` to render our alerts

### DIFF
--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -13,7 +13,3 @@ parameters:
     defaultInstallPlanApproval: Automatic
     defaultSource: openshift-operators-redhat
     defaultSourceNamespace: openshift-operators-redhat
-
-  openshift4_monitoring:
-    alerts:
-      ignoreNames: []

--- a/tests/defaults.yml
+++ b/tests/defaults.yml
@@ -8,6 +8,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/v1.0.2/lib/openshift4-operators.libsonnet
         output_path: vendor/lib/openshift4-operators.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v2.9.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
 
   openshift4_operators:
     defaultInstallPlanApproval: Automatic

--- a/tests/release-5.4.yml
+++ b/tests/release-5.4.yml
@@ -14,9 +14,5 @@ parameters:
     defaultSource: openshift-operators-redhat
     defaultSourceNamespace: openshift-operators-redhat
 
-  openshift4_monitoring:
-    alerts:
-      ignoreNames: []
-
   openshift4_logging:
     version: '5.4'

--- a/tests/release-5.4.yml
+++ b/tests/release-5.4.yml
@@ -8,6 +8,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/v1.0.2/lib/openshift4-operators.libsonnet
         output_path: vendor/lib/openshift4-operators.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v2.9.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
 
   openshift4_operators:
     defaultInstallPlanApproval: Automatic

--- a/tests/syn-monitoring.yml
+++ b/tests/syn-monitoring.yml
@@ -11,6 +11,9 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/projectsyn/component-prometheus/master/lib/prometheus.libsonnet
         output_path: vendor/lib/prometheus.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v2.9.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
 
 
   openshift4_operators:


### PR DESCRIPTION
We've added a component library for patching and filtering alerts in https://github.com/appuio/component-openshift4-monitoring/pull/136 which is released in component opneshift4-monitoring v2.9.0.

This PR uses the library to replace the copy-pasted logic to patch alerts managed by this component.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
