### PR TITLE
Extract upstream alerts from Go files

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "OpenShift4 Logging",
       "slug": "openshift4-logging",
       "parameter_key": "openshift4_logging",
-      "test_cases": "defaults syn-monitoring release-5.4",
+      "test_cases": "defaults syn-monitoring release-5.4 master",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.editorconfig
+++ b/.editorconfig
@@ -34,3 +34,9 @@ indent_size = unset
 indent_style = unset
 insert_final_newline = unset
 trim_trailing_whitespace = unset
+
+[component/extracted_alerts/**]
+indent_size = unset
+indent_style = unset
+insert_final_newline = unset
+trim_trailing_whitespace = unset

--- a/.github/workflows/download-alerts.yaml
+++ b/.github/workflows/download-alerts.yaml
@@ -1,13 +1,44 @@
 name: Download upstream alerts
 on:
+  schedule:
+    - cron: '0 10 * * 1-5'
   workflow_dispatch: {}
 
 env:
   COMPONENT_NAME: openshift4-logging
 
 jobs:
-  linting:
+  alerts:
     runs-on: ubuntu-latest
     steps:
-      - name: message
-        run: echo "This is a placeholder job"
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '>=1.19.0'
+      - name: Download upstream alerts
+        run: make extract-alerts
+      - name: Commit changes to repository
+        run: |
+          set -e
+
+          if [[ -z $(git status --porcelain "${ALERTS_DIR}") ]]; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          make gen-golden-all
+
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+          git switch -c "${ALERTS_UPDATES_BRANCH}"
+          git add "${ALERTS_DIR}" tests/golden
+          git commit -m "Update upstream alerts"
+          git push -u -f origin "${ALERTS_UPDATES_BRANCH}"
+
+          # Check if there is an existing PR that is OPEN or create a new one
+          gh pr view --json 'state' -q '.state == "OPEN" or halt_error(1)' || gh pr create --title "Update upstream alerts" --body "This PR updates the upstream alerts defined in alerts.txt." --label dependency
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ALERTS_DIR: component/extracted_alerts
+          ALERTS_UPDATES_BRANCH: dependencies/update-upstream-alerts

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,7 @@ jobs:
           - defaults
           - syn-monitoring
           - release-5.4
+          - master
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -52,6 +53,7 @@ jobs:
           - defaults
           - syn-monitoring
           - release-5.4
+          - master
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -17,3 +17,4 @@ ignore: |
   vendor/
   compiled/
   tests/golden/
+  component/extracted_alerts/

--- a/Makefile
+++ b/Makefile
@@ -90,3 +90,8 @@ $(test_instances):
 .PHONY: clean
 clean: ## Clean the project
 	rm -rf .cache compiled dependencies vendor helmcharts jsonnetfile*.json || true
+
+.PHONY: extract-alerts
+extract-alerts: ## Extract alerts from upstream go files
+	rm -rf component/extracted_alerts
+	tools/download-upstream-alerts.sh alerts.txt component/extracted_alerts

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/syn-monitoring.yml tests/release-5.4.yml
+test_instances = tests/defaults.yml tests/syn-monitoring.yml tests/release-5.4.yml tests/master.yml

--- a/alerts.txt
+++ b/alerts.txt
@@ -1,0 +1,11 @@
+https://raw.githubusercontent.com/openshift/cluster-logging-operator/release-5.2/files/fluentd/fluentd_prometheus_alerts.yaml release-5.2/fluentd_prometheus_alerts.yaml
+https://raw.githubusercontent.com/openshift/cluster-logging-operator/release-5.3/files/fluentd/fluentd_prometheus_alerts.yaml release-5.3/fluentd_prometheus_alerts.yaml
+https://raw.githubusercontent.com/openshift/cluster-logging-operator/release-5.4/files/fluentd/fluentd_prometheus_alerts.yaml release-5.4/fluentd_prometheus_alerts.yaml
+https://raw.githubusercontent.com/openshift/cluster-logging-operator/release-5.5/files/collector/fluentd_prometheus_alerts.yaml release-5.5/fluentd_prometheus_alerts.yaml
+https://raw.githubusercontent.com/openshift/cluster-logging-operator/master/internal/metrics/alerts/fluentd.go.FluentdPrometheusAlert master/fluentd_prometheus_alerts.yaml
+
+https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-5.2/files/prometheus_alerts.yml release-5.2/elasticsearch_operator_prometheus_alerts.yaml
+https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-5.3/files/prometheus_alerts.yml release-5.3/elasticsearch_operator_prometheus_alerts.yaml
+https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-5.4/files/prometheus_alerts.yml release-5.4/elasticsearch_operator_prometheus_alerts.yaml
+https://raw.githubusercontent.com/openshift/elasticsearch-operator/release-5.5/files/prometheus_alerts.yml release-5.5/elasticsearch_operator_prometheus_alerts.yaml
+https://raw.githubusercontent.com/openshift/elasticsearch-operator/master/files/prometheus_alerts.yml master/elasticsearch_operator_prometheus_alerts.yaml

--- a/class/openshift4-logging.yml
+++ b/class/openshift4-logging.yml
@@ -1,24 +1,5 @@
 parameters:
-  openshift4_logging:
-    =_manifest_paths:
-      fluentd:
-        release-5.2: files/fluentd/fluentd_prometheus_alerts.yaml
-        release-5.3: files/fluentd/fluentd_prometheus_alerts.yaml
-        release-5.4: files/fluentd/fluentd_prometheus_alerts.yaml
-        release-5.5: files/collector/fluentd_prometheus_alerts.yaml
-      elasticsearch-operator:
-        release-5.2: files/prometheus_alerts.yml
-        release-5.3: files/prometheus_alerts.yml
-        release-5.4: files/prometheus_alerts.yml
-        release-5.5: files/prometheus_alerts.yml
   kapitan:
-    dependencies:
-      - type: https
-        source: https://raw.githubusercontent.com/openshift/elasticsearch-operator/${openshift4_logging:alerts}/${openshift4_logging:_manifest_paths:elasticsearch-operator:${openshift4_logging:alerts}}
-        output_path: dependencies/openshift4-logging/manifests/${openshift4_logging:alerts}/elasticsearch_operator_prometheus_alerts.yaml
-      - type: https
-        source: https://raw.githubusercontent.com/openshift/cluster-logging-operator/${openshift4_logging:alerts}/${openshift4_logging:_manifest_paths:fluentd:${openshift4_logging:alerts}}
-        output_path: dependencies/openshift4-logging/manifests/${openshift4_logging:alerts}/fluentd_prometheus_alerts.yaml
     compile:
       - input_paths:
           - openshift4-logging/component/app.jsonnet

--- a/component/alertrules.libsonnet
+++ b/component/alertrules.libsonnet
@@ -36,7 +36,7 @@ local patch_alerts = {
 };
 
 local loadFile(file) =
-  local fpath = 'openshift4-logging/manifests/%s/%s' % [ params.alerts, file ];
+  local fpath = 'openshift4-logging/component/extracted_alerts/%s/%s' % [ params.alerts, file ];
   std.parseJson(kap.yaml_load_stream(fpath));
 
 

--- a/component/extracted_alerts/master/elasticsearch_operator_prometheus_alerts.yaml
+++ b/component/extracted_alerts/master/elasticsearch_operator_prometheus_alerts.yaml
@@ -1,0 +1,224 @@
+---
+"groups":
+- "name": logging_elasticsearch.alerts
+  "rules":
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet."
+      "summary": "Cluster health status is RED"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 2)
+    "for": 7m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated."
+      "summary": "Cluster health status is YELLOW"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 1)
+    "for": 20m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchWriteRequestsRejectionJumps
+    "annotations":
+      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed."
+      "summary": "High Write Rejection Ratio - {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps"
+    "expr": |
+      round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchJVMHeapUseHigh
+    "annotations":
+      "message": "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "JVM Heap usage on the node is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": AggregatedLoggingSystemCPUHigh
+    "annotations":
+      "message": "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "System CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchProcessCPUHigh
+    "annotations":
+      "message": "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "ES process CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchDiskSpaceRunningLow
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h."
+      "summary": "Cluster low on disk space"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low"
+    "expr": |
+      sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchHighFileDescriptorUsage
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour."
+      "summary": "Cluster low on file descriptors"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high"
+    "expr": |
+      predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchOperatorCSVNotSuccessful
+    "annotations":
+      "message": "Elasticsearch Operator CSV has not reconciled succesfully."
+      "summary": "Elasticsearch Operator CSV Not Successful"
+    "expr": |
+      csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning

--- a/component/extracted_alerts/master/fluentd_prometheus_alerts.yaml
+++ b/component/extracted_alerts/master/fluentd_prometheus_alerts.yaml
@@ -1,0 +1,64 @@
+
+"groups":
+- "name": "logging_fluentd.alerts"
+  "rules":
+  - "alert": "FluentdNodeDown"
+    "annotations":
+      "message": "Prometheus could not scrape fluentd {{ $labels.container }} for more than 10m."
+      "summary": "Fluentd cannot be scraped - Test upstream change"
+    "expr": |
+      up{job = "collector", container = "collector"} == 0 or absent(up{job="collector", container="collector"}) == 1
+    "for": "10m"
+    "labels":
+      "service": "collector"
+      "severity": "critical"
+      namespace: "openshift-logging"
+  - "alert": "FluentdQueueLengthIncreasing"
+    "annotations":
+      "message": "For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id }}' average buffer queue length has increased continuously."
+      "summary": "Fluentd pod {{ $labels.pod }} is unable to keep up with traffic over time for forwarder output {{ $labels.plugin_id }}."
+    "expr": |
+      sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
+    "for": "1h"
+    "labels":
+      "service": "collector"
+      "severity": "Warning"
+      namespace: "openshift-logging"
+  - alert: FluentDHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 10
+    for: 15m
+    labels:
+      severity: warning
+      namespace: "openshift-logging"
+  - alert: FluentDVeryHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are very high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 25
+    for: 15m
+    labels:
+      severity: critical
+      namespace: "openshift-logging"
+- "name": "logging_clusterlogging_telemetry.rules"
+  "rules":
+  - "expr": |
+      sum by(cluster)(log_collected_bytes_total)
+    "record": "cluster:log_collected_bytes_total:sum"
+  - "expr": |
+      sum by(cluster)(log_logged_bytes_total)
+    "record": "cluster:log_logged_bytes_total:sum"

--- a/component/extracted_alerts/release-5.2/elasticsearch_operator_prometheus_alerts.yaml
+++ b/component/extracted_alerts/release-5.2/elasticsearch_operator_prometheus_alerts.yaml
@@ -1,0 +1,224 @@
+---
+"groups":
+- "name": logging_elasticsearch.alerts
+  "rules":
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet."
+      "summary": "Cluster health status is RED"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 2)
+    "for": 7m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated."
+      "summary": "Cluster health status is YELLOW"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 1)
+    "for": 20m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchWriteRequestsRejectionJumps
+    "annotations":
+      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed."
+      "summary": "High Write Rejection Ratio - {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps"
+    "expr": |
+      round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchJVMHeapUseHigh
+    "annotations":
+      "message": "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "JVM Heap usage on the node is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": AggregatedLoggingSystemCPUHigh
+    "annotations":
+      "message": "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "System CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchProcessCPUHigh
+    "annotations":
+      "message": "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "ES process CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchDiskSpaceRunningLow
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h."
+      "summary": "Cluster low on disk space"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low"
+    "expr": |
+      sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchHighFileDescriptorUsage
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour."
+      "summary": "Cluster low on file descriptors"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high"
+    "expr": |
+      predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchOperatorCSVNotSuccessful
+    "annotations":
+      "message": "Elasticsearch Operator CSV has not reconciled succesfully."
+      "summary": "Elasticsearch Operator CSV Not Successful"
+    "expr": |
+      csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning

--- a/component/extracted_alerts/release-5.2/fluentd_prometheus_alerts.yaml
+++ b/component/extracted_alerts/release-5.2/fluentd_prometheus_alerts.yaml
@@ -1,0 +1,53 @@
+"groups":
+- "name": "logging_fluentd.alerts"
+  "rules":
+  - "alert": "FluentdNodeDown"
+    "annotations":
+      "message": "Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m."
+      "summary": "Fluentd cannot be scraped"
+    "expr": |
+      absent(up{job="fluentd"} == 1)
+    "for": "10m"
+    "labels":
+      "service": "fluentd"
+      "severity": "critical"
+  - "alert": "FluentdQueueLengthIncreasing"
+    "annotations":
+      "message": "For the last hour, fluentd {{ $labels.instance }} average buffer queue length has increased continuously."
+      "summary": "Fluentd unable to keep up with traffic over time."
+    "expr": |
+      deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1
+    "for": "1h"
+    "labels":
+      "service": "fluentd"
+      "severity": "error"
+  - alert: FluentDHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 10
+    for: 15m
+    labels:
+      severity: warning
+
+  - alert: FluentDVeryHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are very high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 25
+    for: 15m
+    labels:
+      severity: critical
+

--- a/component/extracted_alerts/release-5.3/elasticsearch_operator_prometheus_alerts.yaml
+++ b/component/extracted_alerts/release-5.3/elasticsearch_operator_prometheus_alerts.yaml
@@ -1,0 +1,224 @@
+---
+"groups":
+- "name": logging_elasticsearch.alerts
+  "rules":
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet."
+      "summary": "Cluster health status is RED"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 2)
+    "for": 7m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated."
+      "summary": "Cluster health status is YELLOW"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 1)
+    "for": 20m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchWriteRequestsRejectionJumps
+    "annotations":
+      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed."
+      "summary": "High Write Rejection Ratio - {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps"
+    "expr": |
+      round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchJVMHeapUseHigh
+    "annotations":
+      "message": "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "JVM Heap usage on the node is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": AggregatedLoggingSystemCPUHigh
+    "annotations":
+      "message": "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "System CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchProcessCPUHigh
+    "annotations":
+      "message": "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "ES process CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchDiskSpaceRunningLow
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h."
+      "summary": "Cluster low on disk space"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low"
+    "expr": |
+      sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchHighFileDescriptorUsage
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour."
+      "summary": "Cluster low on file descriptors"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high"
+    "expr": |
+      predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchOperatorCSVNotSuccessful
+    "annotations":
+      "message": "Elasticsearch Operator CSV has not reconciled succesfully."
+      "summary": "Elasticsearch Operator CSV Not Successful"
+    "expr": |
+      csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning

--- a/component/extracted_alerts/release-5.3/fluentd_prometheus_alerts.yaml
+++ b/component/extracted_alerts/release-5.3/fluentd_prometheus_alerts.yaml
@@ -1,0 +1,53 @@
+"groups":
+- "name": "logging_fluentd.alerts"
+  "rules":
+  - "alert": "FluentdNodeDown"
+    "annotations":
+      "message": "Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m."
+      "summary": "Fluentd cannot be scraped"
+    "expr": |
+      absent(up{job="collector"} == 1)
+    "for": "10m"
+    "labels":
+      "service": "fluentd"
+      "severity": "critical"
+  - "alert": "FluentdQueueLengthIncreasing"
+    "annotations":
+      "message": "For the last hour, fluentd {{ $labels.instance }} average buffer queue length has increased continuously."
+      "summary": "Fluentd unable to keep up with traffic over time."
+    "expr": |
+      deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1
+    "for": "1h"
+    "labels":
+      "service": "fluentd"
+      "severity": "error"
+  - alert: FluentDHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 10
+    for: 15m
+    labels:
+      severity: warning
+
+  - alert: FluentDVeryHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are very high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 25
+    for: 15m
+    labels:
+      severity: critical
+

--- a/component/extracted_alerts/release-5.4/elasticsearch_operator_prometheus_alerts.yaml
+++ b/component/extracted_alerts/release-5.4/elasticsearch_operator_prometheus_alerts.yaml
@@ -1,0 +1,224 @@
+---
+"groups":
+- "name": logging_elasticsearch.alerts
+  "rules":
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet."
+      "summary": "Cluster health status is RED"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 2)
+    "for": 7m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated."
+      "summary": "Cluster health status is YELLOW"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 1)
+    "for": 20m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchWriteRequestsRejectionJumps
+    "annotations":
+      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed."
+      "summary": "High Write Rejection Ratio - {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps"
+    "expr": |
+      round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchJVMHeapUseHigh
+    "annotations":
+      "message": "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "JVM Heap usage on the node is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": AggregatedLoggingSystemCPUHigh
+    "annotations":
+      "message": "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "System CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchProcessCPUHigh
+    "annotations":
+      "message": "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "ES process CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchDiskSpaceRunningLow
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h."
+      "summary": "Cluster low on disk space"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low"
+    "expr": |
+      sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchHighFileDescriptorUsage
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour."
+      "summary": "Cluster low on file descriptors"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high"
+    "expr": |
+      predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchOperatorCSVNotSuccessful
+    "annotations":
+      "message": "Elasticsearch Operator CSV has not reconciled succesfully."
+      "summary": "Elasticsearch Operator CSV Not Successful"
+    "expr": |
+      csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning

--- a/component/extracted_alerts/release-5.4/fluentd_prometheus_alerts.yaml
+++ b/component/extracted_alerts/release-5.4/fluentd_prometheus_alerts.yaml
@@ -1,0 +1,53 @@
+"groups":
+- "name": "logging_fluentd.alerts"
+  "rules":
+  - "alert": "FluentdNodeDown"
+    "annotations":
+      "message": "Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m."
+      "summary": "Fluentd cannot be scraped"
+    "expr": |
+      up{job="collector"} == 0 or absent(up{job="collector"}) == 1
+    "for": "10m"
+    "labels":
+      "service": "fluentd"
+      "severity": "critical"
+  - "alert": "FluentdQueueLengthIncreasing"
+    "annotations":
+      "message": "For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id }}' average buffer queue length has increased continuously."
+      "summary": "Fluentd pod {{ $labels.pod }} is unable to keep up with traffic over time for forwarder output {{ $labels.plugin_id }}."
+    "expr": |
+      sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
+    "for": "1h"
+    "labels":
+      "service": "fluentd"
+      "severity": "Warning"
+  - alert: FluentDHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 10
+    for: 15m
+    labels:
+      severity: warning
+
+  - alert: FluentDVeryHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are very high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 25
+    for: 15m
+    labels:
+      severity: critical
+

--- a/component/extracted_alerts/release-5.5/elasticsearch_operator_prometheus_alerts.yaml
+++ b/component/extracted_alerts/release-5.5/elasticsearch_operator_prometheus_alerts.yaml
@@ -1,0 +1,224 @@
+---
+"groups":
+- "name": logging_elasticsearch.alerts
+  "rules":
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been RED for at least 7m. Cluster does not accept writes, shards may be missing or master node hasn't been elected yet."
+      "summary": "Cluster health status is RED"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 2)
+    "for": 7m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchClusterNotHealthy
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} health status has been YELLOW for at least 20m. Some shard replicas are not allocated."
+      "summary": "Cluster health status is YELLOW"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow"
+    "expr": |
+      sum by (cluster) (es_cluster_status == 1)
+    "for": 20m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchWriteRequestsRejectionJumps
+    "annotations":
+      "message": "High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster }} cluster. This node may not be keeping up with the indexing speed."
+      "summary": "High Write Rejection Ratio - {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps"
+    "expr": |
+      round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark Reached - disk saturation is {{ $value }}%"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            es_fs_path_available_bytes /
+            es_fs_path_total_bytes
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 5m
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchJVMHeapUseHigh
+    "annotations":
+      "message": "JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "JVM Heap usage on the node is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": AggregatedLoggingSystemCPUHigh
+    "annotations":
+      "message": "System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "System CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchProcessCPUHigh
+    "annotations":
+      "message": "ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster }} cluster is {{ $value }}%."
+      "summary": "ES process CPU usage is high"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High"
+    "expr": |
+      sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+    "for": 1m
+    "labels":
+      "namespace": openshift-logging
+      "severity": info
+
+  - "alert": ElasticsearchDiskSpaceRunningLow
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of disk space within the next 6h."
+      "summary": "Cluster low on disk space"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low"
+    "expr": |
+      sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": critical
+
+  - "alert": ElasticsearchHighFileDescriptorUsage
+    "annotations":
+      "message": "Cluster {{ $labels.cluster }} is predicted to be out of file descriptors within the next hour."
+      "summary": "Cluster low on file descriptors"
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high"
+    "expr": |
+      predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchOperatorCSVNotSuccessful
+    "annotations":
+      "message": "Elasticsearch Operator CSV has not reconciled succesfully."
+      "summary": "Elasticsearch Operator CSV Not Successful"
+    "expr": |
+      csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+    "for": 10m
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Low Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Shards can not be allocated to this node anymore. You should consider adding more disk to the node."
+      "summary": "Disk Low Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk High Watermark is predicted to be reached within the next 6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different nodes if possible. Make sure more disk space is added to the node or drop old indices allocated to this node."
+      "summary": "Disk High Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning
+
+  - "alert": ElasticsearchNodeDiskWatermarkReached
+    "annotations":
+      "message": "Disk Flood Stage Watermark is predicted to be reached within the next 6h at {{ $labels.pod }}. Every index having a shard allocated on this node is enforced a read-only block. The index block must be released manually when the disk utilization falls below the high watermark."
+      "summary": "Disk Flood Stage Watermark is predicted to be reached within next 6h."
+      "runbook_url": "[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached"
+    "expr": |
+      sum by (instance, pod) (
+        round(
+          (1 - (
+            predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+            predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+          )
+        ) * 100, 0.001)
+      ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
+    "for": 1h
+    "labels":
+      "namespace": openshift-logging
+      "severity": warning

--- a/component/extracted_alerts/release-5.5/fluentd_prometheus_alerts.yaml
+++ b/component/extracted_alerts/release-5.5/fluentd_prometheus_alerts.yaml
@@ -1,0 +1,63 @@
+"groups":
+- "name": "logging_fluentd.alerts"
+  "rules":
+  - "alert": "FluentdNodeDown"
+    "annotations":
+      "message": "Prometheus could not scrape fluentd {{ $labels.instance }} for more than 10m."
+      "summary": "Fluentd cannot be scraped"
+    "expr": |
+      up{job="collector"} == 0 or absent(up{job="collector"}) == 1
+    "for": "10m"
+    "labels":
+      "service": "fluentd"
+      "severity": "critical"
+      namespace: "openshift-logging"
+  - "alert": "FluentdQueueLengthIncreasing"
+    "annotations":
+      "message": "For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id }}' average buffer queue length has increased continuously."
+      "summary": "Fluentd pod {{ $labels.pod }} is unable to keep up with traffic over time for forwarder output {{ $labels.plugin_id }}."
+    "expr": |
+      sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
+    "for": "1h"
+    "labels":
+      "service": "fluentd"
+      "severity": "Warning"
+      namespace: "openshift-logging"
+  - alert: FluentDHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 10
+    for: 15m
+    labels:
+      severity: warning
+      namespace: "openshift-logging"
+  - alert: FluentDVeryHighErrorRate
+    annotations:
+      message: |-
+        {{ $value }}% of records have resulted in an error by fluentd {{ $labels.instance }}.
+      summary: FluentD output errors are very high
+    expr: |
+      100 * (
+        sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+      /
+        sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+      ) > 25
+    for: 15m
+    labels:
+      severity: critical
+      namespace: "openshift-logging"
+- "name": "logging_clusterlogging_telemetry.rules"
+  "rules":
+  - "expr": |
+      sum by(cluster)(log_collected_bytes_total)
+    "record": "cluster:log_collected_bytes_total:sum"
+  - "expr": |
+      sum by(cluster)(log_logged_bytes_total)
+    "record": "cluster:log_logged_bytes_total:sum"

--- a/tests/golden/master/openshift4-logging/openshift4-logging/00_namespace.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/00_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: openshift-logging
+    openshift.io/cluster-monitoring: 'true'
+  name: openshift-logging

--- a/tests/golden/master/openshift4-logging/openshift4-logging/10_operator_group.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/10_operator_group.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  targetNamespaces:
+    - openshift-logging

--- a/tests/golden/master/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -1,0 +1,29 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: elasticsearch-operator
+  name: elasticsearch-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: elasticsearch-operator
+  source: openshift-operators-redhat
+  sourceNamespace: openshift-operators-redhat
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-operators-redhat

--- a/tests/golden/master/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
@@ -1,0 +1,43 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: instance
+  name: instance
+  namespace: openshift-logging
+spec:
+  collection:
+    logs:
+      fluentd: {}
+      type: fluentd
+  curation:
+    curator:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      schedule: 30 3 * * *
+    type: curator
+  logStore:
+    elasticsearch:
+      nodeCount: 3
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      redundancyPolicy: SingleRedundancy
+      storage:
+        size: 200Gi
+    retentionPolicy:
+      application:
+        maxAge: 7d
+      audit:
+        maxAge: 30d
+      infra:
+        maxAge: 30d
+    type: elasticsearch
+  managementState: Managed
+  visualization:
+    kibana:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    type: kibana

--- a/tests/golden/master/openshift4-logging/openshift4-logging/40_journald_configs.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/40_journald_configs.yaml
@@ -1,0 +1,39 @@
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations: {}
+  labels:
+    machineconfiguration.openshift.io/role: master
+    name: 40-master-journald
+  name: 40-master-journald
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,TWF4UmV0ZW50aW9uU2VjPTFtb250aApSYXRlTGltaXRCdXJzdD0xMDAwMApSYXRlTGltaXRJbnRlcnZhbD0xcwpTdG9yYWdlPXBlcnNpc3RlbnQKU3luY0ludGVydmFsU2VjPTFzCg==
+          filesystem: root
+          mode: 420
+          path: /etc/systemd/journald.conf
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  annotations: {}
+  labels:
+    machineconfiguration.openshift.io/role: worker
+    name: 40-worker-journald
+  name: 40-worker-journald
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    storage:
+      files:
+        - contents:
+            source: data:text/plain;charset=utf-8;base64,TWF4UmV0ZW50aW9uU2VjPTFtb250aApSYXRlTGltaXRCdXJzdD0xMDAwMApSYXRlTGltaXRJbnRlcnZhbD0xcwpTdG9yYWdlPXBlcnNpc3RlbnQKU3luY0ludGVydmFsU2VjPTFzCg==
+          filesystem: root
+          mode: 420
+          path: /etc/systemd/journald.conf

--- a/tests/golden/master/openshift4-logging/openshift4-logging/50_networkpolicy.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/50_networkpolicy.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-from-openshift-operators-redhat
+  name: allow-from-openshift-operators-redhat
+  namespace: openshift-logging
+spec:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: openshift-operators-redhat
+        - podSelector:
+            matchLabels:
+              name: elasticsearch-operator
+  podSelector: {}
+  policyTypes:
+    - Ingress

--- a/tests/golden/master/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/60_prometheus_rules.yaml
@@ -1,0 +1,332 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: syn-logging-rules
+  name: syn-logging-rules
+  namespace: openshift-logging
+spec:
+  groups:
+    - name: logging_elasticsearch.alerts
+      rules:
+        - alert: SYN_ElasticsearchClusterNotHealthy
+          annotations:
+            message: Cluster {{ $labels.cluster }} health status has been RED for
+              at least 7m. Cluster does not accept writes, shards may be missing or
+              master node hasn't been elected yet.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Red'
+            summary: Cluster health status is RED
+          expr: 'sum by (cluster) (es_cluster_status == 2)
+
+            '
+          for: 7m
+          labels:
+            namespace: openshift-logging
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchClusterNotHealthy
+          annotations:
+            message: Cluster {{ $labels.cluster }} health status has been YELLOW for
+              at least 20m. Some shard replicas are not allocated.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Cluster-Health-is-Yellow'
+            summary: Cluster health status is YELLOW
+          expr: 'sum by (cluster) (es_cluster_status == 1)
+
+            '
+          for: 20m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchWriteRequestsRejectionJumps
+          annotations:
+            message: High Write Rejection Ratio at {{ $labels.node }} node in {{ $labels.cluster
+              }} cluster. This node may not be keeping up with the indexing speed.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Write-Requests-Rejection-Jumps'
+            summary: High Write Rejection Ratio - {{ $value }}%
+          expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
+
+            '
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
+          annotations:
+            message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can
+              not be allocated to this node anymore. You should consider adding more
+              disk to the node.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+            summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
+          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+            \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
+          annotations:
+            message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards
+              will be re-allocated to different nodes if possible. Make sure more
+              disk space is added to the node or drop old indices allocated to this
+              node.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+            summary: Disk High Watermark Reached - disk saturation is {{ $value }}%
+          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+            \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
+          annotations:
+            message: Disk Flood Stage Watermark Reached at {{ $labels.pod }}. Every
+              index having a shard allocated on this node is enforced a read-only
+              block. The index block must be released manually when the disk utilization
+              falls below the high watermark.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+            summary: Disk Flood Stage Watermark Reached - disk saturation is {{ $value
+              }}%
+          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
+            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
+            \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchJVMHeapUseHigh
+          annotations:
+            message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
+              }} cluster is {{ $value }}%.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-JVM-Heap-Use-is-High'
+            summary: JVM Heap usage on the node is high
+          expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) >
+            75
+
+            '
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_AggregatedLoggingSystemCPUHigh
+          annotations:
+            message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+              }} cluster is {{ $value }}%.
+            runbook_url: '[[.RunbookBaseURL]]#Aggregated-Logging-System-CPU-is-High'
+            summary: System CPU usage is high
+          expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
+
+            '
+          for: 1m
+          labels:
+            namespace: openshift-logging
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchProcessCPUHigh
+          annotations:
+            message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
+              }} cluster is {{ $value }}%.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Process-CPU-is-High'
+            summary: ES process CPU usage is high
+          expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
+
+            '
+          for: 1m
+          labels:
+            namespace: openshift-logging
+            severity: info
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchDiskSpaceRunningLow
+          annotations:
+            message: Cluster {{ $labels.cluster }} is predicted to be out of disk
+              space within the next 6h.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Disk-Space-is-Running-Low'
+            summary: Cluster low on disk space
+          expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
+
+            '
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchHighFileDescriptorUsage
+          annotations:
+            message: Cluster {{ $labels.cluster }} is predicted to be out of file
+              descriptors within the next hour.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-FileDescriptor-Usage-is-high'
+            summary: Cluster low on file descriptors
+          expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
+            - predict_linear(es_process_file_descriptors_open_number[1h], 3600) <
+            0
+
+            '
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchOperatorCSVNotSuccessful
+          annotations:
+            message: Elasticsearch Operator CSV has not reconciled succesfully.
+            summary: Elasticsearch Operator CSV Not Successful
+          expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
+
+            '
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
+          annotations:
+            message: Disk Low Watermark is predicted to be reached within the next
+              6h at {{ $labels.pod }} pod. Shards can not be allocated to this node
+              anymore. You should consider adding more disk to the node.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Low-Watermark-Reached'
+            summary: Disk Low Watermark is predicted to be reached within next 6h.
+          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
+            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
+          annotations:
+            message: Disk High Watermark is predicted to be reached within the next
+              6h at {{ $labels.pod }} pod. Some shards will be re-allocated to different
+              nodes if possible. Make sure more disk space is added to the node or
+              drop old indices allocated to this node.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-High-Watermark-Reached'
+            summary: Disk High Watermark is predicted to be reached within next 6h.
+          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
+            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
+          annotations:
+            message: Disk Flood Stage Watermark is predicted to be reached within
+              the next 6h at {{ $labels.pod }}. Every index having a shard allocated
+              on this node is enforced a read-only block. The index block must be
+              released manually when the disk utilization falls below the high watermark.
+            runbook_url: '[[.RunbookBaseURL]]#Elasticsearch-Node-Disk-Flood-Watermark-Reached'
+            summary: Disk Flood Stage Watermark is predicted to be reached within
+              next 6h.
+          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
+            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
+            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+          for: 1h
+          labels:
+            namespace: openshift-logging
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+    - name: logging_fluentd.alerts
+      rules:
+        - alert: SYN_FluentdNodeDown
+          annotations:
+            message: Prometheus could not scrape fluentd {{ $labels.container }} for
+              more than 10m.
+            summary: Fluentd cannot be scraped - Test upstream change
+          expr: 'up{job = "collector", container = "collector"} == 0 or absent(up{job="collector",
+            container="collector"}) == 1
+
+            '
+          for: 10m
+          labels:
+            namespace: openshift-logging
+            service: collector
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentdQueueLengthIncreasing
+          annotations:
+            message: For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id
+              }}' average buffer queue length has increased continuously.
+            summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
+              over time for forwarder output {{ $labels.plugin_id }}.
+          expr: 'sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m]
+            offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
+            > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
+
+            '
+          for: 12h
+          labels:
+            namespace: openshift-logging
+            service: collector
+            severity: Warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentDHighErrorRate
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by fluentd
+              {{ $labels.instance }}.'
+            summary: FluentD output errors are high
+          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+            ) > 10\n"
+          for: 15m
+          labels:
+            namespace: openshift-logging
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentDVeryHighErrorRate
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by fluentd
+              {{ $labels.instance }}.'
+            summary: FluentD output errors are very high
+          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
+            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
+            ) > 25\n"
+          for: 15m
+          labels:
+            namespace: openshift-logging
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+    - name: elasticsearch_node_storage.alerts
+      rules:
+        - alert: SYN_ElasticsearchExpectNodeToReachDiskWatermark
+          annotations:
+            message: Expecting to reach disk low watermark at {{ $labels.node }} node
+              in {{ $labels.cluster }} cluster in 72 hours. When reaching the watermark
+              no new shards will be allocated to this node anymore. You should consider
+              adding more disk to the node.
+            runbook_url: https://hub.syn.tools/openshift4-logging/runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.html
+            summary: Expecting to Reach Disk Low Watermark in 72 Hours
+          expr: "sum by(cluster, instance, node) (\n  (1 - (predict_linear(es_fs_path_available_bytes[72h],\
+            \ 259200) / es_fs_path_total_bytes)) * 100\n) > 85\n"
+          for: 6h
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging

--- a/tests/master.yml
+++ b/tests/master.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/master.yml
+++ b/tests/master.yml
@@ -1,3 +1,22 @@
-# Overwrite parameters here
+applications:
+  - openshift4-operators as openshift-operators-redhat
+  - openshift4-monitoring
 
-# parameters: {...}
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/v1.0.2/lib/openshift4-operators.libsonnet
+        output_path: vendor/lib/openshift4-operators.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v2.9.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
+
+  openshift4_operators:
+    defaultInstallPlanApproval: Automatic
+    defaultSource: openshift-operators-redhat
+    defaultSourceNamespace: openshift-operators-redhat
+
+  openshift4_logging:
+    channel: 'stable'
+    alerts: 'master'

--- a/tools/download-upstream-alerts.sh
+++ b/tools/download-upstream-alerts.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+if [ $# -lt 2 ]; then
+  echo "Usage: $0 <alerts-txt> <output-dir>"
+  exit 3
+fi
+
+alerts_txt=$1
+output_dir=$2
+
+IFS=$'\n' read -d '' -r -a downloads < <(cat "$alerts_txt";printf '\0')
+
+for i in "${downloads[@]}"; do
+  read -r url l _ <<<"$i"
+  l="$output_dir/$l"
+
+  echo "Downloading $url to $l"
+
+  mkdir -p "$(dirname "$l")"
+
+  if [[ "$url" == *".yaml" || "$url" == *".yml" ]]; then
+      echo "Downloading yaml directly from $url"
+      wget --no-verbose -O "$l" "$url"
+  else
+    extract=${url##*.}
+    url=${url%.*}
+
+    echo "Downloading $url (needs extraction)"
+    wget --no-verbose -O "$l~" "$url"
+    echo "Extracting $l~ Go constant $extract to $l"
+    go run github.com/bastjan/declextract@latest "$l~" "$extract" > "$l"
+    rm "$l~"
+  fi
+done


### PR DESCRIPTION
This PR adds a make target and script to download upstream alerts from either yaml or Go top level constants/variables.

The workflow runs once a day during the week and creates or updates the existing [PR](https://github.com/appuio/component-openshift4-logging/pull/79/commits/01bfaf1645e65a511ea962d25df1155fab823097). 

Fixes #47 and #74.

Uses (the very experimental) https://github.com/bastjan/declextract to extract declarations.

The PR is quite big but the important parts are:
- [download-alerts.yaml](https://github.com/appuio/component-openshift4-logging/blob/bd906f9a2b3356cc837892c8359e97d28713a62c/.github/workflows/download-alerts.yaml)
- [download-upstream-alerts.sh](https://github.com/appuio/component-openshift4-logging/blob/bd906f9a2b3356cc837892c8359e97d28713a62c/tools/download-upstream-alerts.sh)

## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
