### PR TITLE
Enable logging view plugin in console

### DIFF
--- a/component/loki.libsonnet
+++ b/component/loki.libsonnet
@@ -2,6 +2,7 @@
 local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
+local po = import 'lib/patch-operator.libsonnet';
 
 // The hiera parameters for the component
 local inv = kap.inventory();
@@ -92,12 +93,22 @@ local netpol_lokigateway = kube.NetworkPolicy('allow-console-logging-lokistack-g
   },
 };
 
+local console_patch = po.Patch(
+  kube._Object('operator.openshift.io/v1', 'Console', 'cluster'),
+  {
+    spec: {
+      plugins: [ 'logging-view-plugin' ],
+    },
+  },
+);
+
 // Define outputs below
 if loki.enabled then
   {
     '50_loki_stack': lokistack,
     '50_loki_logstore': logstore,
     '50_loki_netpol': [ netpol_viewplugin, netpol_lokigateway ],
+    '50_loki_console_patch': console_patch,
   }
 else
   std.trace(

--- a/tests/golden/lokistack/openshift4-logging/openshift4-logging/50_loki_console_patch.yaml
+++ b/tests/golden/lokistack/openshift4-logging/openshift4-logging/50_loki_console_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: redhatcop.redhat.io/v1alpha1
+kind: Patch
+metadata:
+  annotations: {}
+  labels:
+    name: console-cluster-cc0c21c0e8849f4
+  name: console-cluster-cc0c21c0e8849f4
+  namespace: syn-patch-operator
+spec:
+  patches:
+    patch1:
+      patchTemplate: "\"spec\":\n  \"plugins\":\n  - \"logging-view-plugin\""
+      patchType: application/strategic-merge-patch+json
+      targetObjectRef:
+        apiVersion: operator.openshift.io/v1
+        kind: Console
+        name: cluster
+  serviceAccountRef:
+    name: syn-patch-operator

--- a/tests/lokistack.yml
+++ b/tests/lokistack.yml
@@ -11,6 +11,14 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v2.9.0/lib/openshift4-monitoring-alert-patching.libsonnet
         output_path: vendor/lib/alert-patching.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/projectsyn/component-patch-operator/v1.0.0/lib/patch-operator.libsonnet
+        output_path: vendor/lib/patch-operator.libsonnet
+
+  patch_operator:
+    namespace: syn-patch-operator
+    patch_serviceaccount:
+      name: syn-patch-operator
 
   openshift4_operators:
     defaultInstallPlanApproval: Automatic

--- a/tests/lokistack.yml
+++ b/tests/lokistack.yml
@@ -12,7 +12,7 @@ parameters:
         source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v2.9.0/lib/openshift4-monitoring-alert-patching.libsonnet
         output_path: vendor/lib/alert-patching.libsonnet
       - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-patch-operator/v1.0.0/lib/patch-operator.libsonnet
+        source: https://raw.githubusercontent.com/projectsyn/component-patch-operator/v1.1.0/lib/patch-operator.libsonnet
         output_path: vendor/lib/patch-operator.libsonnet
 
   patch_operator:


### PR DESCRIPTION
Enables the logging view plugin in the OpenShift console by patching the cluster-scoped console object.


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
