### PR TITLE
Fix openshift-console config when deploying EFK stack

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -5,7 +5,7 @@ parameters:
         config:
           plugins:
             - "logging-view-plugin"
-      "False":
+      "False": {}
 
     namespace: openshift-logging
     version: '5.6'

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
@@ -17,9 +17,8 @@ spec:
               master node hasn't been elected yet.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Red
             summary: Cluster health status is RED
-          expr: 'sum by (cluster) (es_cluster_status == 2)
-
-            '
+          expr: |
+            sum by (cluster) (es_cluster_status == 2)
           for: 7m
           labels:
             namespace: openshift-logging
@@ -32,9 +31,8 @@ spec:
               at least 20m. Some shard replicas are not allocated.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Yellow
             summary: Cluster health status is YELLOW
-          expr: 'sum by (cluster) (es_cluster_status == 1)
-
-            '
+          expr: |
+            sum by (cluster) (es_cluster_status == 1)
           for: 20m
           labels:
             namespace: openshift-logging
@@ -47,9 +45,8 @@ spec:
               }} cluster. This node may not be keeping up with the indexing speed.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Write-Requests-Rejection-Jumps
             summary: High Write Rejection Ratio - {{ $value }}%
-          expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
-
-            '
+          expr: |
+            round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
           for: 10m
           labels:
             namespace: openshift-logging
@@ -63,9 +60,15 @@ spec:
               disk to the node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
             summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -80,9 +83,15 @@ spec:
               node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached
             summary: Disk High Watermark Reached - disk saturation is {{ $value }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -98,9 +107,15 @@ spec:
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached
             summary: Disk Flood Stage Watermark Reached - disk saturation is {{ $value
               }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -113,10 +128,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-JVM-Heap-Use-is-High
             summary: JVM Heap usage on the node is high
-          expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) >
-            75
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
           for: 10m
           labels:
             namespace: openshift-logging
@@ -129,9 +142,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High
             summary: System CPU usage is high
-          expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_os_cpu_percent) > 90
           for: 1m
           labels:
             namespace: openshift-logging
@@ -144,9 +156,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High
             summary: ES process CPU usage is high
-          expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_process_cpu_percent) > 90
           for: 1m
           labels:
             namespace: openshift-logging
@@ -159,9 +170,8 @@ spec:
               space within the next 6h.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Disk-Space-is-Running-Low
             summary: Cluster low on disk space
-          expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
-
-            '
+          expr: |
+            sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
           for: 1h
           labels:
             namespace: openshift-logging
@@ -174,11 +184,8 @@ spec:
               descriptors within the next hour.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-FileDescriptor-Usage-is-high
             summary: Cluster low on file descriptors
-          expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
-            - predict_linear(es_process_file_descriptors_open_number[1h], 3600) <
-            0
-
-            '
+          expr: |
+            predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
           for: 10m
           labels:
             namespace: openshift-logging
@@ -189,9 +196,8 @@ spec:
           annotations:
             message: Elasticsearch Operator CSV has not reconciled succesfully.
             summary: Elasticsearch Operator CSV Not Successful
-          expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
-
-            '
+          expr: |
+            csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
           for: 10m
           labels:
             namespace: openshift-logging
@@ -205,9 +211,15 @@ spec:
               anymore. You should consider adding more disk to the node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
             summary: Disk Low Watermark is predicted to be reached within next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -222,9 +234,15 @@ spec:
               drop old indices allocated to this node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached
             summary: Disk High Watermark is predicted to be reached within next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -240,9 +258,15 @@ spec:
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached
             summary: Disk Flood Stage Watermark is predicted to be reached within
               next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -256,10 +280,8 @@ spec:
             message: Prometheus could not scrape fluentd {{ $labels.container }} for
               more than 10m.
             summary: Fluentd cannot be scraped
-          expr: 'up{job = "collector", container = "collector"} == 0 or absent(up{job="collector",
-            container="collector"}) == 1
-
-            '
+          expr: |
+            up{job = "collector", container = "collector"} == 0 or absent(up{job="collector", container="collector"}) == 1
           for: 10m
           labels:
             namespace: openshift-logging
@@ -273,11 +295,8 @@ spec:
               }}' average buffer queue length has increased continuously.
             summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
               over time for forwarder output {{ $labels.plugin_id }}.
-          expr: 'sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m]
-            offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
-            > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
-
-            '
+          expr: |
+            sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
           for: 12h
           labels:
             namespace: openshift-logging
@@ -290,9 +309,12 @@ spec:
             message: '{{ $value }}% of records have resulted in an error by fluentd
               {{ $labels.instance }}.'
             summary: FluentD output errors are high
-          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
-            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
-            ) > 10\n"
+          expr: |
+            100 * (
+              sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+            /
+              sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+            ) > 10
           for: 15m
           labels:
             namespace: openshift-logging
@@ -304,9 +326,12 @@ spec:
             message: '{{ $value }}% of records have resulted in an error by fluentd
               {{ $labels.instance }}.'
             summary: FluentD output errors are very high
-          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
-            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
-            ) > 25\n"
+          expr: |
+            100 * (
+              sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+            /
+              sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+            ) > 25
           for: 15m
           labels:
             namespace: openshift-logging
@@ -323,8 +348,10 @@ spec:
               adding more disk to the node.
             runbook_url: https://hub.syn.tools/openshift4-logging/runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.html
             summary: Expecting to Reach Disk Low Watermark in 72 Hours
-          expr: "sum by(cluster, instance, node) (\n  (1 - (predict_linear(es_fs_path_available_bytes[72h],\
-            \ 259200) / es_fs_path_total_bytes)) * 100\n) > 85\n"
+          expr: |
+            sum by(cluster, instance, node) (
+              (1 - (predict_linear(es_fs_path_available_bytes[72h], 259200) / es_fs_path_total_bytes)) * 100
+            ) > 85
           for: 6h
           labels:
             severity: warning

--- a/tests/golden/lokistack/openshift4-logging/openshift4-logging/60_lokistack_alerts.yaml
+++ b/tests/golden/lokistack/openshift4-logging/openshift4-logging/60_lokistack_alerts.yaml
@@ -16,9 +16,16 @@ spec:
               "%.2f" $value }}% errors.'
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Request-Errors
             summary: At least 10% of requests are responded by 5xx server errors.
-          expr: "sum(\n  job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m{status_code=~\"\
-            5..\"}\n) by (job, namespace, route)\n/\nsum(\n  job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m\n\
-            ) by (job, namespace, route)\n* 100\n> 10\n"
+          expr: |
+            sum(
+              job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m{status_code=~"5.."}
+            ) by (job, namespace, route)
+            /
+            sum(
+              job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m
+            ) by (job, namespace, route)
+            * 100
+            > 10
           for: 15m
           labels:
             severity: critical
@@ -31,9 +38,16 @@ spec:
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#LokiStack-Write-Request-Errors
             summary: At least 10% of write requests to the lokistack-gateway are responded
               with 5xx server errors.
-          expr: "sum(\n  code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{code=~\"\
-            5..\", handler=\"push\"}\n) by (job, namespace)\n/\nsum(\n  code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{handler=\"\
-            push\"}\n) by (job, namespace)\n* 100\n> 10\n"
+          expr: |
+            sum(
+              code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{code=~"5..", handler="push"}
+            ) by (job, namespace)
+            /
+            sum(
+              code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{handler="push"}
+            ) by (job, namespace)
+            * 100
+            > 10
           for: 15m
           labels:
             severity: critical
@@ -46,11 +60,16 @@ spec:
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#LokiStack-Read-Request-Errors
             summary: At least 10% of query requests to the lokistack-gateway are responded
               with 5xx server errors.
-          expr: "sum(\n  code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{code=~\"\
-            5..\", handler=~\"query|query_range|label|labels|label_values\"}\n) by\
-            \ (job, namespace)\n/\nsum(\n  code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{handler=~\"\
-            query|query_range|label|labels|label_values\"}\n) by (job, namespace)\n\
-            * 100\n> 10\n"
+          expr: |
+            sum(
+              code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{code=~"5..", handler=~"query|query_range|label|labels|label_values"}
+            ) by (job, namespace)
+            /
+            sum(
+              code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{handler=~"query|query_range|label|labels|label_values"}
+            ) by (job, namespace)
+            * 100
+            > 10
           for: 15m
           labels:
             severity: critical
@@ -62,8 +81,13 @@ spec:
               panics.'
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Request-Panics
             summary: A panic was triggered.
-          expr: "sum(\n  increase(\n    loki_panic_total[10m]\n  )\n) by (job, namespace)\n\
-            > 0\n"
+          expr: |
+            sum(
+              increase(
+                loki_panic_total[10m]
+              )
+            ) by (job, namespace)
+            > 0
           labels:
             severity: critical
             syn: 'true'
@@ -75,8 +99,15 @@ spec:
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Request-Latency
             summary: The 99th percentile is experiencing high latency (higher than
               1 second).
-          expr: "histogram_quantile(0.99,\n  sum(\n    irate(\n      loki_request_duration_seconds_bucket{route!~\"\
-            (?i).*tail.*\"}[1m]\n    )\n  ) by (job, le, namespace, route)\n)\n> 1\n"
+          expr: |
+            histogram_quantile(0.99,
+              sum(
+                irate(
+                  loki_request_duration_seconds_bucket{route!~"(?i).*tail.*"}[1m]
+                )
+              ) by (job, le, namespace, route)
+            )
+            > 1
           for: 15m
           labels:
             severity: critical
@@ -88,9 +119,16 @@ spec:
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Tenant-Rate-Limit
             summary: At least 10% of requests are responded with the rate limit error
               code.
-          expr: "sum(\n  job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m{status_code=\"\
-            429\"}\n) by (job, namespace, route)\n/\nsum(\n  job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m\n\
-            ) by (job, namespace, route)\n* 100\n> 10\n"
+          expr: |
+            sum(
+              job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m{status_code="429"}
+            ) by (job, namespace, route)
+            /
+            sum(
+              job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m
+            ) by (job, namespace, route)
+            * 100
+            > 10
           for: 15m
           labels:
             severity: warning
@@ -101,8 +139,13 @@ spec:
             message: The storage path is experiencing slow write response rates.
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Storage-Slow-Write
             summary: The storage path is experiencing slow write response rates.
-          expr: "histogram_quantile(0.99,\n  sum(\n    job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation=\"\
-            WRITE\"}\n  ) by (job, le, namespace)\n)\n> 1\n"
+          expr: |
+            histogram_quantile(0.99,
+              sum(
+                job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation="WRITE"}
+              ) by (job, le, namespace)
+            )
+            > 1
           for: 15m
           labels:
             severity: warning
@@ -113,8 +156,13 @@ spec:
             message: The storage path is experiencing slow read response rates.
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Storage-Slow-Read
             summary: The storage path is experiencing slow read response rates.
-          expr: "histogram_quantile(0.99,\n  sum(\n    job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation=\"\
-            Shipper.Query\"}\n  ) by (job, le, namespace)\n)\n> 5\n"
+          expr: |
+            histogram_quantile(0.99,
+              sum(
+                job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation="Shipper.Query"}
+              ) by (job, le, namespace)
+            )
+            > 5
           for: 15m
           labels:
             severity: warning
@@ -126,8 +174,11 @@ spec:
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Write-Path-High-Load
             summary: The write path is experiencing high load, causing backpressure
               storage flushing.
-          expr: "sum(\n  loki_ingester_wal_replay_flushing\n) by (job, namespace)\n\
-            > 0\n"
+          expr: |
+            sum(
+              loki_ingester_wal_replay_flushing
+            ) by (job, namespace)
+            > 0
           for: 15m
           labels:
             severity: warning
@@ -139,8 +190,15 @@ spec:
             runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Read-Path-High-Load
             summary: The read path has high volume of queries, causing longer response
               times.
-          expr: "histogram_quantile(0.99,\n  sum(\n    rate(\n      loki_logql_querystats_latency_seconds_bucket[5m]\n\
-            \    )\n  ) by (job, le, namespace)\n)\n> 30\n"
+          expr: |
+            histogram_quantile(0.99,
+              sum(
+                rate(
+                  loki_logql_querystats_latency_seconds_bucket[5m]
+                )
+              ) by (job, le, namespace)
+            )
+            > 30
           for: 15m
           labels:
             severity: warning

--- a/tests/golden/master/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
@@ -17,9 +17,8 @@ spec:
               master node hasn't been elected yet.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Red
             summary: Cluster health status is RED
-          expr: 'sum by (cluster) (es_cluster_status == 2)
-
-            '
+          expr: |
+            sum by (cluster) (es_cluster_status == 2)
           for: 7m
           labels:
             namespace: openshift-logging
@@ -32,9 +31,8 @@ spec:
               at least 20m. Some shard replicas are not allocated.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Yellow
             summary: Cluster health status is YELLOW
-          expr: 'sum by (cluster) (es_cluster_status == 1)
-
-            '
+          expr: |
+            sum by (cluster) (es_cluster_status == 1)
           for: 20m
           labels:
             namespace: openshift-logging
@@ -47,9 +45,8 @@ spec:
               }} cluster. This node may not be keeping up with the indexing speed.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Write-Requests-Rejection-Jumps
             summary: High Write Rejection Ratio - {{ $value }}%
-          expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
-
-            '
+          expr: |
+            round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
           for: 10m
           labels:
             namespace: openshift-logging
@@ -63,9 +60,15 @@ spec:
               disk to the node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
             summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -80,9 +83,15 @@ spec:
               node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached
             summary: Disk High Watermark Reached - disk saturation is {{ $value }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -98,9 +107,15 @@ spec:
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached
             summary: Disk Flood Stage Watermark Reached - disk saturation is {{ $value
               }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -113,10 +128,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-JVM-Heap-Use-is-High
             summary: JVM Heap usage on the node is high
-          expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) >
-            75
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
           for: 10m
           labels:
             namespace: openshift-logging
@@ -129,9 +142,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High
             summary: System CPU usage is high
-          expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_os_cpu_percent) > 90
           for: 1m
           labels:
             namespace: openshift-logging
@@ -144,9 +156,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High
             summary: ES process CPU usage is high
-          expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_process_cpu_percent) > 90
           for: 1m
           labels:
             namespace: openshift-logging
@@ -159,9 +170,8 @@ spec:
               space within the next 6h.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Disk-Space-is-Running-Low
             summary: Cluster low on disk space
-          expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
-
-            '
+          expr: |
+            sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
           for: 1h
           labels:
             namespace: openshift-logging
@@ -174,11 +184,8 @@ spec:
               descriptors within the next hour.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-FileDescriptor-Usage-is-high
             summary: Cluster low on file descriptors
-          expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
-            - predict_linear(es_process_file_descriptors_open_number[1h], 3600) <
-            0
-
-            '
+          expr: |
+            predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
           for: 10m
           labels:
             namespace: openshift-logging
@@ -189,9 +196,8 @@ spec:
           annotations:
             message: Elasticsearch Operator CSV has not reconciled succesfully.
             summary: Elasticsearch Operator CSV Not Successful
-          expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
-
-            '
+          expr: |
+            csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
           for: 10m
           labels:
             namespace: openshift-logging
@@ -205,9 +211,15 @@ spec:
               anymore. You should consider adding more disk to the node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
             summary: Disk Low Watermark is predicted to be reached within next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -222,9 +234,15 @@ spec:
               drop old indices allocated to this node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached
             summary: Disk High Watermark is predicted to be reached within next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -240,9 +258,15 @@ spec:
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached
             summary: Disk Flood Stage Watermark is predicted to be reached within
               next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -256,10 +280,8 @@ spec:
             message: Prometheus could not scrape fluentd {{ $labels.container }} for
               more than 10m.
             summary: Fluentd cannot be scraped
-          expr: 'up{job = "collector", container = "collector"} == 0 or absent(up{job="collector",
-            container="collector"}) == 1
-
-            '
+          expr: |
+            up{job = "collector", container = "collector"} == 0 or absent(up{job="collector", container="collector"}) == 1
           for: 10m
           labels:
             namespace: openshift-logging
@@ -273,11 +295,8 @@ spec:
               }}' average buffer queue length has increased continuously.
             summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
               over time for forwarder output {{ $labels.plugin_id }}.
-          expr: 'sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m]
-            offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
-            > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
-
-            '
+          expr: |
+            sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
           for: 12h
           labels:
             namespace: openshift-logging
@@ -290,9 +309,12 @@ spec:
             message: '{{ $value }}% of records have resulted in an error by fluentd
               {{ $labels.instance }}.'
             summary: FluentD output errors are high
-          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
-            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
-            ) > 10\n"
+          expr: |
+            100 * (
+              sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+            /
+              sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+            ) > 10
           for: 15m
           labels:
             namespace: openshift-logging
@@ -304,9 +326,12 @@ spec:
             message: '{{ $value }}% of records have resulted in an error by fluentd
               {{ $labels.instance }}.'
             summary: FluentD output errors are very high
-          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
-            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
-            ) > 25\n"
+          expr: |
+            100 * (
+              sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+            /
+              sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+            ) > 25
           for: 15m
           labels:
             namespace: openshift-logging
@@ -323,8 +348,10 @@ spec:
               adding more disk to the node.
             runbook_url: https://hub.syn.tools/openshift4-logging/runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.html
             summary: Expecting to Reach Disk Low Watermark in 72 Hours
-          expr: "sum by(cluster, instance, node) (\n  (1 - (predict_linear(es_fs_path_available_bytes[72h],\
-            \ 259200) / es_fs_path_total_bytes)) * 100\n) > 85\n"
+          expr: |
+            sum by(cluster, instance, node) (
+              (1 - (predict_linear(es_fs_path_available_bytes[72h], 259200) / es_fs_path_total_bytes)) * 100
+            ) > 85
           for: 6h
           labels:
             severity: warning

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
@@ -17,9 +17,8 @@ spec:
               master node hasn't been elected yet.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Red
             summary: Cluster health status is RED
-          expr: 'sum by (cluster) (es_cluster_status == 2)
-
-            '
+          expr: |
+            sum by (cluster) (es_cluster_status == 2)
           for: 7m
           labels:
             namespace: openshift-logging
@@ -32,9 +31,8 @@ spec:
               at least 20m. Some shard replicas are not allocated.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Cluster-Health-is-Yellow
             summary: Cluster health status is YELLOW
-          expr: 'sum by (cluster) (es_cluster_status == 1)
-
-            '
+          expr: |
+            sum by (cluster) (es_cluster_status == 1)
           for: 20m
           labels:
             namespace: openshift-logging
@@ -47,9 +45,8 @@ spec:
               }} cluster. This node may not be keeping up with the indexing speed.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Write-Requests-Rejection-Jumps
             summary: High Write Rejection Ratio - {{ $value }}%
-          expr: 'round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
-
-            '
+          expr: |
+            round( writing:reject_ratio:rate2m * 100, 0.001 ) > 5
           for: 10m
           labels:
             namespace: openshift-logging
@@ -63,9 +60,15 @@ spec:
               disk to the node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
             summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -80,9 +83,15 @@ spec:
               node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached
             summary: Disk High Watermark Reached - disk saturation is {{ $value }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -98,9 +107,15 @@ spec:
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached
             summary: Disk Flood Stage Watermark Reached - disk saturation is {{ $value
               }}%
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      es_fs_path_available_bytes\
-            \ /\n      es_fs_path_total_bytes\n    )\n  ) * 100, 0.001)\n) > on(instance,\
-            \ pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  es_fs_path_available_bytes /
+                  es_fs_path_total_bytes
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
           for: 5m
           labels:
             namespace: openshift-logging
@@ -113,10 +128,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-JVM-Heap-Use-is-High
             summary: JVM Heap usage on the node is high
-          expr: 'sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) >
-            75
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
           for: 10m
           labels:
             namespace: openshift-logging
@@ -129,9 +142,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High
             summary: System CPU usage is high
-          expr: 'sum by (cluster, instance, node) (es_os_cpu_percent) > 90
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_os_cpu_percent) > 90
           for: 1m
           labels:
             namespace: openshift-logging
@@ -144,9 +156,8 @@ spec:
               }} cluster is {{ $value }}%.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High
             summary: ES process CPU usage is high
-          expr: 'sum by (cluster, instance, node) (es_process_cpu_percent) > 90
-
-            '
+          expr: |
+            sum by (cluster, instance, node) (es_process_cpu_percent) > 90
           for: 1m
           labels:
             namespace: openshift-logging
@@ -159,9 +170,8 @@ spec:
               space within the next 6h.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Disk-Space-is-Running-Low
             summary: Cluster low on disk space
-          expr: 'sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
-
-            '
+          expr: |
+            sum(predict_linear(es_fs_path_available_bytes[6h], 6 * 3600)) < 0
           for: 1h
           labels:
             namespace: openshift-logging
@@ -174,11 +184,8 @@ spec:
               descriptors within the next hour.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-FileDescriptor-Usage-is-high
             summary: Cluster low on file descriptors
-          expr: 'predict_linear(es_process_file_descriptors_max_number[1h], 3600)
-            - predict_linear(es_process_file_descriptors_open_number[1h], 3600) <
-            0
-
-            '
+          expr: |
+            predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
           for: 10m
           labels:
             namespace: openshift-logging
@@ -189,9 +196,8 @@ spec:
           annotations:
             message: Elasticsearch Operator CSV has not reconciled succesfully.
             summary: Elasticsearch Operator CSV Not Successful
-          expr: 'csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
-
-            '
+          expr: |
+            csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
           for: 10m
           labels:
             namespace: openshift-logging
@@ -205,9 +211,15 @@ spec:
               anymore. You should consider adding more disk to the node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
             summary: Disk Low Watermark is predicted to be reached within next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -222,9 +234,15 @@ spec:
               drop old indices allocated to this node.
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-High-Watermark-Reached
             summary: Disk High Watermark is predicted to be reached within next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_high_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -240,9 +258,15 @@ spec:
             runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Flood-Watermark-Reached
             summary: Disk Flood Stage Watermark is predicted to be reached within
               next 6h.
-          expr: "sum by (instance, pod) (\n  round(\n    (1 - (\n      predict_linear(es_fs_path_available_bytes[3h],\
-            \ 6 * 3600) /\n      predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)\n\
-            \    )\n  ) * 100, 0.001)\n) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct\n"
+          expr: |
+            sum by (instance, pod) (
+              round(
+                (1 - (
+                  predict_linear(es_fs_path_available_bytes[3h], 6 * 3600) /
+                  predict_linear(es_fs_path_total_bytes[3h], 6 * 3600)
+                )
+              ) * 100, 0.001)
+            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_flood_stage_pct
           for: 1h
           labels:
             namespace: openshift-logging
@@ -256,9 +280,8 @@ spec:
             message: Prometheus could not scrape fluentd {{ $labels.instance }} for
               more than 10m.
             summary: Fluentd cannot be scraped
-          expr: 'up{job="collector"} == 0 or absent(up{job="collector"}) == 1
-
-            '
+          expr: |
+            up{job="collector"} == 0 or absent(up{job="collector"}) == 1
           for: 10m
           labels:
             service: fluentd
@@ -271,11 +294,8 @@ spec:
               }}' average buffer queue length has increased continuously.
             summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
               over time for forwarder output {{ $labels.plugin_id }}.
-          expr: 'sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m]
-            offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m])
-            > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
-
-            '
+          expr: |
+            sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
           for: 12h
           labels:
             service: fluentd
@@ -287,9 +307,12 @@ spec:
             message: '{{ $value }}% of records have resulted in an error by fluentd
               {{ $labels.instance }}.'
             summary: FluentD output errors are high
-          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
-            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
-            ) > 10\n"
+          expr: |
+            100 * (
+              sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+            /
+              sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+            ) > 10
           for: 15m
           labels:
             severity: warning
@@ -300,9 +323,12 @@ spec:
             message: '{{ $value }}% of records have resulted in an error by fluentd
               {{ $labels.instance }}.'
             summary: FluentD output errors are very high
-          expr: "100 * (\n  sum by(instance)(rate(fluentd_output_status_num_errors[2m]))\n\
-            /\n  sum by(instance)(rate(fluentd_output_status_emit_records[2m]))\n\
-            ) > 25\n"
+          expr: |
+            100 * (
+              sum by(instance)(rate(fluentd_output_status_num_errors[2m]))
+            /
+              sum by(instance)(rate(fluentd_output_status_emit_records[2m]))
+            ) > 25
           for: 15m
           labels:
             severity: critical
@@ -318,8 +344,10 @@ spec:
               adding more disk to the node.
             runbook_url: https://hub.syn.tools/openshift4-logging/runbooks/SYN_ElasticsearchExpectNodeToReachDiskWatermark.html
             summary: Expecting to Reach Disk Low Watermark in 72 Hours
-          expr: "sum by(cluster, instance, node) (\n  (1 - (predict_linear(es_fs_path_available_bytes[72h],\
-            \ 259200) / es_fs_path_total_bytes)) * 100\n) > 85\n"
+          expr: |
+            sum by(cluster, instance, node) (
+              (1 - (predict_linear(es_fs_path_available_bytes[72h], 259200) / es_fs_path_total_bytes)) * 100
+            ) > 85
           for: 6h
           labels:
             severity: warning


### PR DESCRIPTION
Previously, the component set parameter `openshift4_console` to `null` (an empty YAML value is treated as null) when the EFK stack is being deployed, this breaks catalog compilation for existing setups because it wipes the openshift4-console component defaults, if this component's defaults are included after the console defaults.

This commit fixes the bug by setting `openshift4_console: {}` if the EFK stack is being deployed.

Fixes #97 


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
