### PR TITLE
Add resource requests and limits to operator subscriptions

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -98,6 +98,26 @@ parameters:
         typekey: 'kubernetes.labels.logFormat'
         typename: 'nologformat'
 
+    operatorResources:
+      clusterLogging:
+        requests:
+          memory: 128Mi
+          cpu: 10m
+        limits:
+          memory: 256Mi
+      lokistack:
+        requests:
+          memory: 381Mi
+          cpu: 50m
+        limits:
+          memory: 512Mi
+      elasticsearch:
+        requests:
+          memory: 1Gi
+          cpu: 100m
+        limits:
+          memory: 1.5Gi
+
   openshift4_elasticsearch_operator:
     targetNamespaces:
       - ${openshift4_logging:namespace}

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -50,14 +50,26 @@ local namespace_groups = (
       'cluster-logging',
       params.channel,
       'redhat-operators'
-    ),
+    ) {
+      spec+: {
+        config+: {
+          resources: params.operatorResources.clusterLogging,
+        },
+      },
+    },
   ] + (
     if params.components.lokistack.enabled then [
       operatorlib.managedSubscription(
         'openshift-operators-redhat',
         'loki-operator',
         params.channel
-      ),
+      ) {
+        spec+: {
+          config+: {
+            resources: params.operatorResources.lokistack,
+          },
+        },
+      },
     ] else []
   ) + (
     if params.components.elasticsearch.enabled then [
@@ -65,7 +77,13 @@ local namespace_groups = (
         'openshift-operators-redhat',
         'elasticsearch-operator',
         params.channel
-      ),
+      ) {
+        spec+: {
+          config+: {
+            resources: params.operatorResources.elasticsearch,
+          },
+        },
+      },
     ] else []
   ),
   '30_cluster_logging': std.mergePatch(

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -293,6 +293,14 @@ The default of 5 MiB/s allows up to ~420 GiB of logs per day for a tenant.
 See the https://docs.openshift.com/container-platform/latest/logging/cluster-logging-loki.html#logging-loki-deploy_cluster-logging-loki[Openshift Docs] for available parameters.
 See the https://loki-operator.dev/docs/api.md/[Loki Operator Docs] for available Lokistack specs.
 
+== `operatorResources`
+
+[horizontal]
+type:: dictionary
+default:: see `defaults.yml`
+
+A dictionary holding the `.spec.config.resources` for OLM subscriptions maintained by this component.
+
 
 == `clusterLogging`
 

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -8,6 +8,13 @@ metadata:
   namespace: openshift-logging
 spec:
   channel: stable-5.6
+  config:
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators
@@ -23,6 +30,13 @@ metadata:
   namespace: openshift-operators-redhat
 spec:
   channel: stable-5.6
+  config:
+    resources:
+      limits:
+        memory: 1.5Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
   installPlanApproval: Automatic
   name: elasticsearch-operator
   source: openshift-operators-redhat

--- a/tests/golden/lokistack/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/lokistack/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -8,6 +8,13 @@ metadata:
   namespace: openshift-logging
 spec:
   channel: stable-5.6
+  config:
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators
@@ -23,6 +30,13 @@ metadata:
   namespace: openshift-operators-redhat
 spec:
   channel: stable-5.6
+  config:
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 381Mi
   installPlanApproval: Automatic
   name: loki-operator
   source: openshift-operators-redhat

--- a/tests/golden/master/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -8,6 +8,13 @@ metadata:
   namespace: openshift-logging
 spec:
   channel: stable
+  config:
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators
@@ -23,6 +30,13 @@ metadata:
   namespace: openshift-operators-redhat
 spec:
   channel: stable
+  config:
+    resources:
+      limits:
+        memory: 1.5Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
   installPlanApproval: Automatic
   name: elasticsearch-operator
   source: openshift-operators-redhat

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -8,6 +8,13 @@ metadata:
   namespace: openshift-logging
 spec:
   channel: stable-5.4
+  config:
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
   installPlanApproval: Automatic
   name: cluster-logging
   source: redhat-operators
@@ -23,6 +30,13 @@ metadata:
   namespace: openshift-operators-redhat
 spec:
   channel: stable-5.4
+  config:
+    resources:
+      limits:
+        memory: 1.5Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
   installPlanApproval: Automatic
   name: elasticsearch-operator
   source: openshift-operators-redhat


### PR DESCRIPTION
The requests and limits are derived from metrics of existing deployments. Resource usage on all operators looks very stable.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
