### PR TITLE
Disable low-value alerts by default

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -12,7 +12,10 @@ parameters:
     channel: 'stable-${openshift4_logging:version}'
     alerts: 'release-${openshift4_logging:version}'
 
-    ignore_alerts: []
+    ignore_alerts:
+      - ElasticsearchHighFileDescriptorUsage
+      - ElasticsearchOperatorCSVNotSuccessful
+      - FluentdQueueLengthIncreasing
 
     components:
       lokistack:

--- a/component/alertrules.libsonnet
+++ b/component/alertrules.libsonnet
@@ -97,6 +97,14 @@ local renderRunbookBaseURL(group, baseURL) = {
   ),
 };
 
+local dropInfoRules =
+  local drop(rule) =
+    local rlbls = std.get(rule, 'labels', {});
+    std.get(rlbls, 'severity', '') == 'info';
+  {
+    rules: std.filter(function(rule) !drop(rule), super.rules),
+  };
+
 local prometheus_rules(name, groups, baseURL) = kube._Object('monitoring.coreos.com/v1', 'PrometheusRule', name) {
   metadata+: {
     namespace: params.namespace,
@@ -105,7 +113,7 @@ local prometheus_rules(name, groups, baseURL) = kube._Object('monitoring.coreos.
     groups: std.filter(
       function(it) it != null,
       [
-        local r = alertpatching.filterPatchRules(g, ignore_alerts, patch_alerts);
+        local r = alertpatching.filterPatchRules(g + dropInfoRules, ignore_alerts, patch_alerts);
         local s = renderRunbookBaseURL(r, baseURL);
         if std.length(s.rules) > 0 then s
         for g in groups

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
@@ -55,28 +55,6 @@ spec:
             syn_component: openshift4-logging
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
-            message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can
-              not be allocated to this node anymore. You should consider adding more
-              disk to the node.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
-            summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-          expr: |
-            sum by (instance, pod) (
-              round(
-                (1 - (
-                  es_fs_path_available_bytes /
-                  es_fs_path_total_bytes
-                )
-              ) * 100, 0.001)
-            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
-          for: 5m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
-          annotations:
             message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards
               will be re-allocated to different nodes if possible. Make sure more
               disk space is added to the node or drop old indices allocated to this
@@ -122,48 +100,6 @@ spec:
             severity: critical
             syn: 'true'
             syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchJVMHeapUseHigh
-          annotations:
-            message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-JVM-Heap-Use-is-High
-            summary: JVM Heap usage on the node is high
-          expr: |
-            sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_AggregatedLoggingSystemCPUHigh
-          annotations:
-            message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High
-            summary: System CPU usage is high
-          expr: |
-            sum by (cluster, instance, node) (es_os_cpu_percent) > 90
-          for: 1m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchProcessCPUHigh
-          annotations:
-            message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High
-            summary: ES process CPU usage is high
-          expr: |
-            sum by (cluster, instance, node) (es_process_cpu_percent) > 90
-          for: 1m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
         - alert: SYN_ElasticsearchDiskSpaceRunningLow
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of disk
@@ -176,32 +112,6 @@ spec:
           labels:
             namespace: openshift-logging
             severity: critical
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchHighFileDescriptorUsage
-          annotations:
-            message: Cluster {{ $labels.cluster }} is predicted to be out of file
-              descriptors within the next hour.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-FileDescriptor-Usage-is-high
-            summary: Cluster low on file descriptors
-          expr: |
-            predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: warning
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchOperatorCSVNotSuccessful
-          annotations:
-            message: Elasticsearch Operator CSV has not reconciled succesfully.
-            summary: Elasticsearch Operator CSV Not Successful
-          expr: |
-            csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: warning
             syn: 'true'
             syn_component: openshift4-logging
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
@@ -287,21 +197,6 @@ spec:
             namespace: openshift-logging
             service: collector
             severity: critical
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_FluentdQueueLengthIncreasing
-          annotations:
-            message: For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id
-              }}' average buffer queue length has increased continuously.
-            summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
-              over time for forwarder output {{ $labels.plugin_id }}.
-          expr: |
-            sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
-          for: 12h
-          labels:
-            namespace: openshift-logging
-            service: collector
-            severity: Warning
             syn: 'true'
             syn_component: openshift4-logging
         - alert: SYN_FluentDHighErrorRate

--- a/tests/golden/master/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
@@ -55,28 +55,6 @@ spec:
             syn_component: openshift4-logging
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
-            message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can
-              not be allocated to this node anymore. You should consider adding more
-              disk to the node.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
-            summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-          expr: |
-            sum by (instance, pod) (
-              round(
-                (1 - (
-                  es_fs_path_available_bytes /
-                  es_fs_path_total_bytes
-                )
-              ) * 100, 0.001)
-            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
-          for: 5m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
-          annotations:
             message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards
               will be re-allocated to different nodes if possible. Make sure more
               disk space is added to the node or drop old indices allocated to this
@@ -122,48 +100,6 @@ spec:
             severity: critical
             syn: 'true'
             syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchJVMHeapUseHigh
-          annotations:
-            message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-JVM-Heap-Use-is-High
-            summary: JVM Heap usage on the node is high
-          expr: |
-            sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_AggregatedLoggingSystemCPUHigh
-          annotations:
-            message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High
-            summary: System CPU usage is high
-          expr: |
-            sum by (cluster, instance, node) (es_os_cpu_percent) > 90
-          for: 1m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchProcessCPUHigh
-          annotations:
-            message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High
-            summary: ES process CPU usage is high
-          expr: |
-            sum by (cluster, instance, node) (es_process_cpu_percent) > 90
-          for: 1m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
         - alert: SYN_ElasticsearchDiskSpaceRunningLow
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of disk
@@ -176,32 +112,6 @@ spec:
           labels:
             namespace: openshift-logging
             severity: critical
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchHighFileDescriptorUsage
-          annotations:
-            message: Cluster {{ $labels.cluster }} is predicted to be out of file
-              descriptors within the next hour.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-FileDescriptor-Usage-is-high
-            summary: Cluster low on file descriptors
-          expr: |
-            predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: warning
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchOperatorCSVNotSuccessful
-          annotations:
-            message: Elasticsearch Operator CSV has not reconciled succesfully.
-            summary: Elasticsearch Operator CSV Not Successful
-          expr: |
-            csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: warning
             syn: 'true'
             syn_component: openshift4-logging
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
@@ -287,21 +197,6 @@ spec:
             namespace: openshift-logging
             service: collector
             severity: critical
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_FluentdQueueLengthIncreasing
-          annotations:
-            message: For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id
-              }}' average buffer queue length has increased continuously.
-            summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
-              over time for forwarder output {{ $labels.plugin_id }}.
-          expr: |
-            sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
-          for: 12h
-          labels:
-            namespace: openshift-logging
-            service: collector
-            severity: Warning
             syn: 'true'
             syn_component: openshift4-logging
         - alert: SYN_FluentDHighErrorRate

--- a/tests/golden/release-5.4/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
+++ b/tests/golden/release-5.4/openshift4-logging/openshift4-logging/60_elasticsearch_alerts.yaml
@@ -55,28 +55,6 @@ spec:
             syn_component: openshift4-logging
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
           annotations:
-            message: Disk Low Watermark Reached at {{ $labels.pod }} pod. Shards can
-              not be allocated to this node anymore. You should consider adding more
-              disk to the node.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Node-Disk-Low-Watermark-Reached
-            summary: Disk Low Watermark Reached - disk saturation is {{ $value }}%
-          expr: |
-            sum by (instance, pod) (
-              round(
-                (1 - (
-                  es_fs_path_available_bytes /
-                  es_fs_path_total_bytes
-                )
-              ) * 100, 0.001)
-            ) > on(instance, pod) es_cluster_routing_allocation_disk_watermark_low_pct
-          for: 5m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchNodeDiskWatermarkReached
-          annotations:
             message: Disk High Watermark Reached at {{ $labels.pod }} pod. Some shards
               will be re-allocated to different nodes if possible. Make sure more
               disk space is added to the node or drop old indices allocated to this
@@ -122,48 +100,6 @@ spec:
             severity: critical
             syn: 'true'
             syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchJVMHeapUseHigh
-          annotations:
-            message: JVM Heap usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-JVM-Heap-Use-is-High
-            summary: JVM Heap usage on the node is high
-          expr: |
-            sum by (cluster, instance, node) (es_jvm_mem_heap_used_percent) > 75
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_AggregatedLoggingSystemCPUHigh
-          annotations:
-            message: System CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Aggregated-Logging-System-CPU-is-High
-            summary: System CPU usage is high
-          expr: |
-            sum by (cluster, instance, node) (es_os_cpu_percent) > 90
-          for: 1m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchProcessCPUHigh
-          annotations:
-            message: ES process CPU usage on the node {{ $labels.node }} in {{ $labels.cluster
-              }} cluster is {{ $value }}%.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-Process-CPU-is-High
-            summary: ES process CPU usage is high
-          expr: |
-            sum by (cluster, instance, node) (es_process_cpu_percent) > 90
-          for: 1m
-          labels:
-            namespace: openshift-logging
-            severity: info
-            syn: 'true'
-            syn_component: openshift4-logging
         - alert: SYN_ElasticsearchDiskSpaceRunningLow
           annotations:
             message: Cluster {{ $labels.cluster }} is predicted to be out of disk
@@ -176,32 +112,6 @@ spec:
           labels:
             namespace: openshift-logging
             severity: critical
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchHighFileDescriptorUsage
-          annotations:
-            message: Cluster {{ $labels.cluster }} is predicted to be out of file
-              descriptors within the next hour.
-            runbook_url: https://github.com/openshift/elasticsearch-operator/blob/master/docs/alerts.md#Elasticsearch-FileDescriptor-Usage-is-high
-            summary: Cluster low on file descriptors
-          expr: |
-            predict_linear(es_process_file_descriptors_max_number[1h], 3600) - predict_linear(es_process_file_descriptors_open_number[1h], 3600) < 0
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: warning
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_ElasticsearchOperatorCSVNotSuccessful
-          annotations:
-            message: Elasticsearch Operator CSV has not reconciled succesfully.
-            summary: Elasticsearch Operator CSV Not Successful
-          expr: |
-            csv_succeeded{name =~ "elasticsearch-operator.*"} == 0
-          for: 10m
-          labels:
-            namespace: openshift-logging
-            severity: warning
             syn: 'true'
             syn_component: openshift4-logging
         - alert: SYN_ElasticsearchNodeDiskWatermarkReached
@@ -286,20 +196,6 @@ spec:
           labels:
             service: fluentd
             severity: critical
-            syn: 'true'
-            syn_component: openshift4-logging
-        - alert: SYN_FluentdQueueLengthIncreasing
-          annotations:
-            message: For the last hour, fluentd {{ $labels.pod }} output '{{ $labels.plugin_id
-              }}' average buffer queue length has increased continuously.
-            summary: Fluentd pod {{ $labels.pod }} is unable to keep up with traffic
-              over time for forwarder output {{ $labels.plugin_id }}.
-          expr: |
-            sum by (pod,plugin_id) ( 0 * (deriv(fluentd_output_status_emit_records[1m] offset 1h)))  + on(pod,plugin_id)  ( deriv(fluentd_output_status_buffer_queue_length[10m]) > 0 and delta(fluentd_output_status_buffer_queue_length[1h]) > 1 )
-          for: 12h
-          labels:
-            service: fluentd
-            severity: Warning
             syn: 'true'
             syn_component: openshift4-logging
         - alert: SYN_FluentDHighErrorRate


### PR DESCRIPTION
Disable all `severity=info` alerts, and add a few low-value alerts to the ignore list in `class/defaults.yml`




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
