### PR TITLE
Skip missing `LokiStack` CRD in ArgoCD dry-run

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,6 +35,7 @@ jobs:
           - defaults
           - release-5.4
           - master
+          - lokistack
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -52,6 +53,7 @@ jobs:
           - defaults
           - release-5.4
           - master
+          - lokistack
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/component/loki.libsonnet
+++ b/component/loki.libsonnet
@@ -47,6 +47,12 @@ local lokistack_spec = {
 };
 
 local lokistack = kube._Object('loki.grafana.com/v1', 'LokiStack', 'loki') {
+  metadata+: {
+    annotations+: {
+      // Allow ArgoCD to do the dry run when the CRD doesn't exist yet
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
+  },
   spec: lokistack_spec + com.makeMergeable(loki.spec),
 };
 

--- a/tests/golden/lokistack/openshift4-logging/openshift4-logging/50_loki_stack.yaml
+++ b/tests/golden/lokistack/openshift4-logging/openshift4-logging/50_loki_stack.yaml
@@ -1,7 +1,8 @@
 apiVersion: loki.grafana.com/v1
 kind: LokiStack
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: loki
   name: loki


### PR DESCRIPTION
This allows ArgoCD to continue with syncing the component on first install.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
