### PR TITLE
Add support for configuring log access in LokiStack for `cluster-reader`

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -20,6 +20,9 @@ parameters:
     components:
       lokistack:
         enabled: false
+        clusterReaderLogAccess:
+          - application
+          - infrastructure
         logStore:
           access_key_id: ''
           access_key_secret: ''

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -191,36 +191,34 @@ The severity of the fired alert.
 
 == `components.lokistack`
 
+Configuration of the lokistack component.
+See subsections for supported keys.
+
+=== `components.lokistack.enabled`
+
 [horizontal]
-type:: dictionary
+type:: boolean
+default:: `false`
+
+Whether to deploy the LokiStack on the cluster.
+
+
+=== `components.lokistack.clusterReaderLogAccess`
+
+[horizontal]
+type:: list
 default::
 +
 [source,yaml]
 ----
-components:
-  lokistack:
-    enabled: false
-    logStore:
-      access_key_id: ''
-      access_key_secret: ''
-      endpoint: ''
-      bucketnames: '${cluster:name}-logstore'
-    spec:
-      size: 1x.extra-small
-      storage:
-        schemas:
-          - version: v12
-            effectiveDate: '2022-06-01'
-        secret:
-          type: s3
-          name: loki-logstore
-      storageClassName: ''
-      tenants:
-        mode: openshift-logging
+- application
+- infrastructure
 ----
 
-Configuration of the lokistack component.
+A list of log categories (supported values are `application`, `infrastructure` and `audit`) which can be viewed by users which have `cluster-reader` permissions.
+Entries in the list can be removed in the hierarchy by prefixing them with `~`.
 
+NOTE: We don't grant access to audit logs to `cluster-reader` by default since audit logs can contain sensitive information.
 
 === `components.lokistack.logStore`
 

--- a/tests/golden/lokistack/openshift4-logging/openshift4-logging/50_loki_rbac.yaml
+++ b/tests/golden/lokistack/openshift4-logging/openshift4-logging/50_loki_rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-loki-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:loki:cluster-reader
+rules:
+  - apiGroups:
+      - loki.grafana.com
+    resourceNames:
+      - logs
+    resources:
+      - application
+      - infrastructure
+    verbs:
+      - get


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
