### PR TITLE
Bump replica count for LokiStack read path to 2 for 1x.demo

### DIFF
--- a/component/loki.libsonnet
+++ b/component/loki.libsonnet
@@ -20,7 +20,7 @@ local lokistack_spec = {
       nodeSelector: { 'node-role.kubernetes.io/infra': '' },
     },
     gateway: {
-      [if loki.spec.size == '1x.demo' then 'replicas']: 1,
+      [if loki.spec.size == '1x.demo' then 'replicas']: 2,
       nodeSelector: { 'node-role.kubernetes.io/infra': '' },
     },
     indexGateway: {
@@ -32,11 +32,11 @@ local lokistack_spec = {
       nodeSelector: { 'node-role.kubernetes.io/infra': '' },
     },
     querier: {
-      [if loki.spec.size == '1x.demo' then 'replicas']: 1,
+      [if loki.spec.size == '1x.demo' then 'replicas']: 2,
       nodeSelector: { 'node-role.kubernetes.io/infra': '' },
     },
     queryFrontend: {
-      [if loki.spec.size == '1x.demo' then 'replicas']: 1,
+      [if loki.spec.size == '1x.demo' then 'replicas']: 2,
       nodeSelector: { 'node-role.kubernetes.io/infra': '' },
     },
     ruler: {

--- a/tests/golden/lokistack/openshift4-logging/openshift4-logging/50_loki_stack.yaml
+++ b/tests/golden/lokistack/openshift4-logging/openshift4-logging/50_loki_stack.yaml
@@ -33,7 +33,7 @@ spec:
     gateway:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 1
+      replicas: 2
     indexGateway:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
@@ -45,11 +45,11 @@ spec:
     querier:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 1
+      replicas: 2
     queryFrontend:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 1
+      replicas: 2
     ruler:
       nodeSelector:
         node-role.kubernetes.io/infra: ''


### PR DESCRIPTION
Cluster-logging 5.8 introduces PDBs for the Loki stack. Unfortunately the PDBs are created unconditionally, and block node drains when deploying LokiStack with `1x.demo`.

We adjust the replica count for the LokiStack read path (gateway, querier, queryfrontend) to 2, so that we can drain infra nodes without violating the PDBs for those components.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
