### PR TITLE
Run the loki ingester workaround every 10 minutes

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -130,7 +130,7 @@ parameters:
 
     workaround:
       ingester_fix:
-        schedule: '0,30 * * * *'
+        schedule: '*/10 * * * *'
         sleep_time: 2m
 
   openshift4_elasticsearch_operator:

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/50_loki_ingester_fix.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/50_loki_ingester_fix.yaml
@@ -150,4 +150,4 @@ spec:
                 defaultMode: 364
                 name: loki-ingester-check
               name: wal-check
-  schedule: 0,30 * * * *
+  schedule: '*/10 * * * *'

--- a/tests/golden/master/openshift4-logging/openshift4-logging/50_loki_ingester_fix.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/50_loki_ingester_fix.yaml
@@ -150,4 +150,4 @@ spec:
                 defaultMode: 364
                 name: loki-ingester-check
               name: wal-check
-  schedule: 0,30 * * * *
+  schedule: '*/10 * * * *'

--- a/tests/golden/multilineerr/openshift4-logging/openshift4-logging/50_loki_ingester_fix.yaml
+++ b/tests/golden/multilineerr/openshift4-logging/openshift4-logging/50_loki_ingester_fix.yaml
@@ -150,4 +150,4 @@ spec:
                 defaultMode: 364
                 name: loki-ingester-check
               name: wal-check
-  schedule: 0,30 * * * *
+  schedule: '*/10 * * * *'


### PR DESCRIPTION
This helps to prevent NodeDrainStuck alerts from firing in the situation where the first ingester pod doesn't come up during the maintenance.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
