### PR TITLE
Fix elasticsearch-operator deprecated in stable-5.9

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -2,6 +2,7 @@ local com = import 'lib/commodore.libjsonnet';
 local kap = import 'lib/kapitan.libjsonnet';
 local kube = import 'lib/kube.libjsonnet';
 local operatorlib = import 'lib/openshift4-operators.libsonnet';
+local utils = import 'utils.libsonnet';
 
 local inv = kap.inventory();
 local params = inv.parameters.openshift4_logging;
@@ -62,10 +63,13 @@ local lokistack = if deployLokistack then operatorlib.managedSubscription(
   },
 };
 
+// With version 5.9 of the logging stack, elasticsearch is deprecated,
+// this will clamp elasticsearch-operator subscription to stable-5.8.
+local esChannel = if utils.isVersion59 then 'stable-5.8' else params.channel;
 local elasticsearch = if deployElasticsearch then operatorlib.managedSubscription(
   'openshift-operators-redhat',
   'elasticsearch-operator',
-  'stable-5.8'
+  esChannel
 ) {
   spec+: {
     config+: {

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -65,7 +65,7 @@ local lokistack = if deployLokistack then operatorlib.managedSubscription(
 local elasticsearch = if deployElasticsearch then operatorlib.managedSubscription(
   'openshift-operators-redhat',
   'elasticsearch-operator',
-  params.channel
+  'stable-5.8'
 ) {
   spec+: {
     config+: {

--- a/component/utils.libsonnet
+++ b/component/utils.libsonnet
@@ -1,0 +1,26 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local params = inv.parameters.openshift4_logging;
+
+local isVersion58 =
+  local major = std.split(params.version, '.')[0];
+  local minor = std.split(params.version, '.')[1];
+  if major == 'master' then true
+  else if std.parseInt(major) >= 6 then true
+  else if std.parseInt(major) == 5 && std.parseInt(minor) >= 8 then true
+  else false;
+
+local isVersion59 =
+  local major = std.split(params.version, '.')[0];
+  local minor = std.split(params.version, '.')[1];
+  if major == 'master' then true
+  else if std.parseInt(major) >= 6 then true
+  else if std.parseInt(major) == 5 && std.parseInt(minor) >= 9 then true
+  else false;
+
+{
+  isVersion58: isVersion58,
+  isVersion59: isVersion59,
+}

--- a/tests/golden/elasticsearch/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/elasticsearch/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -29,7 +29,7 @@ metadata:
   name: elasticsearch-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: stable-5.9
+  channel: stable-5.8
   config:
     resources:
       limits:


### PR DESCRIPTION


## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
