### PR TITLE
Support creating LogFileMetricsExporter CR

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -57,6 +57,18 @@ parameters:
           threshold: 85
           for: 6h
           severity: warning
+      logmetrics:
+        enabled: false
+        spec:
+          nodeSelector:
+            node-role.kubernetes.io/infra: ''
+          resources:
+            limits:
+              cpu: 500m
+              memory: 256Mi
+            requests:
+              cpu: 200m
+              memory: 128Mi
 
     clusterLogging: {}
 

--- a/component/logmetrics.libsonnet
+++ b/component/logmetrics.libsonnet
@@ -1,0 +1,21 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+
+local inv = kap.inventory();
+local logmetrics = inv.parameters.openshift4_logging.components.logmetrics;
+
+local logMetricExporter = kube._Object('logging.openshift.io/v1alpha1', 'LogFileMetricExporter', 'instance') {
+  spec: logmetrics.spec,
+};
+
+
+// Define outputs below
+if logmetrics.enabled then
+  {
+    '70_logmetricsexporter': logMetricExporter,
+  }
+else
+  std.trace(
+    'Logmetrics disabled, not deploying LogFileMetricExporter',
+    {}
+  )

--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -95,3 +95,4 @@ local subscriptions = std.filter(function(it) it != null, [
 + (import 'loki.libsonnet')
 + (import 'elasticsearch.libsonnet')
 + (import 'alertrules.libsonnet')
++ (import 'logmetrics.libsonnet')

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -295,6 +295,46 @@ The default of 5 MiB/s allows up to ~420 GiB of logs per day for a tenant.
 See the https://docs.openshift.com/container-platform/latest/observability/logging/cluster-logging-deploying.html#configuring-log-storage-cr_cluster-logging-deploying[Openshift Docs] for available parameters.
 See the https://loki-operator.dev/docs/api.md/[Loki Operator Docs] for available Lokistack specs.
 
+
+== `components.logmetrics`
+
+Configuration of the logfile metrics component.
+See subsections for supported keys.
+
+=== `components.logmetrics.enabled`
+
+[horizontal]
+type:: boolean
+default:: `false`
+
+Whether to deploy the LogFileMetricsExporter on the cluster.
+
+
+=== `components.logmetrics.spec`
+
+[horizontal]
+type:: dictionary
+default::
++
+[source,yaml]
+----
+spec:
+  nodeSelector: <1>
+    node-role.kubernetes.io/infra: ''
+  resources: <2>
+    limits:
+      cpu: 500m
+      memory: 256Mi
+    requests:
+      cpu: 200m
+      memory: 128Mi
+----
+<1> configure nodeSelector
+<2> configure resources
+
+See the https://docs.openshift.com/container-platform/latest/observability/logging/log_collection_forwarding/cluster-logging-collector.html#creating-logfilesmetricexporter_cluster-logging-collector[LogCollection Docs] for available specs.
+
+
 == `operatorResources`
 
 [horizontal]


### PR DESCRIPTION
In logging version 5.8 and newer versions, the LogFileMetricExporter is no longer deployed with the collector by default. You must manually create a LogFileMetricExporter custom resource (CR) to generate metrics from the logs produced by running containers.

If you do not create the LogFileMetricExporter CR, you may see a No datapoints found message in the OpenShift Container Platform web console dashboard for Produced Logs.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
