### PR TITLE
Refactor configuration of ClusterLogForwarder

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -7,7 +7,7 @@
       "name": "OpenShift4 Logging",
       "slug": "openshift4-logging",
       "parameter_key": "openshift4_logging",
-      "test_cases": "defaults master elasticsearch multilineerr forwardingonly",
+      "test_cases": "defaults master elasticsearch multilineerr forwardingonly legacy",
       "add_lib": "n",
       "add_pp": "n",
       "add_golden": "y",

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,6 +38,7 @@ jobs:
           - elasticsearch
           - multilineerr
           - forwardingonly
+          - legacy
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}
@@ -57,6 +58,7 @@ jobs:
           - elasticsearch
           - multilineerr
           - forwardingonly
+          - legacy
     defaults:
       run:
         working-directory: ${{ env.COMPONENT_NAME }}

--- a/Makefile.vars.mk
+++ b/Makefile.vars.mk
@@ -57,4 +57,4 @@ KUBENT_IMAGE    ?= ghcr.io/doitintl/kube-no-trouble:latest
 KUBENT_DOCKER   ?= $(DOCKER_CMD) $(DOCKER_ARGS) $(root_volume) --entrypoint=/app/kubent $(KUBENT_IMAGE)
 
 instance ?= defaults
-test_instances = tests/defaults.yml tests/master.yml tests/elasticsearch.yml tests/multilineerr.yml tests/forwardingonly.yml
+test_instances = tests/defaults.yml tests/master.yml tests/elasticsearch.yml tests/multilineerr.yml tests/forwardingonly.yml tests/legacy.yml

--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -71,20 +71,7 @@ parameters:
               memory: 128Mi
 
     clusterLogging: {}
-
-    clusterLogForwarding:
-      enabled: false
-      forwarders: {}
-      namespace_groups: {}
-      application_logs: {}
-      audit_logs:
-        enabled: false
-      infrastructure_logs:
-        enabled: true
-      json:
-        enabled: false
-        typekey: 'kubernetes.labels.logFormat'
-        typename: 'nologformat'
+    clusterLogForwarder: {}
 
     operatorResources:
       clusterLogging:

--- a/docs/modules/ROOT/pages/how-tos/upgrade-v3.x-v4.x.adoc
+++ b/docs/modules/ROOT/pages/how-tos/upgrade-v3.x-v4.x.adoc
@@ -1,0 +1,6 @@
+= Upgrade from v3.x to v4.x
+
+The parameter `clusterLogForwarding` is deprecated.
+The component is backwards compatible, but moving the parameters to `clusterLogForwarder` is highly encouraged.
+
+See xref:references/parameters.adoc#_examples[Examples] for reference.

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -103,10 +103,7 @@ components:
 
 Configuration of the elasticsearch component.
 
-[NOTE]
-====
-Elasticsearch is deprecated.
-====
+IMPORTANT: Elasticsearch is deprecated.
 
 === `components.elasticsearch.kibana_host`
 
@@ -348,183 +345,30 @@ A dictionary holding the `.spec.config.resources` for OLM subscriptions maintain
 
 [horizontal]
 type:: dictionary
-default:: see `defaults.yml`
+default:: {}
 
 A dictionary holding the `.spec` for cluster logging.
 
 See the https://docs.openshift.com/container-platform/latest/observability/logging/cluster-logging-deploying.html#create-cluster-logging-cli_cluster-logging-deploying[OpenShift docs] for available parameters.
 
 
+== `clusterLogForwarder`
+
+[horizontal]
+type:: dictionary
+default:: {}
+
+A dictionary holding the `.spec` for cluster log forwarding.
+
+See the https://docs.openshift.com/container-platform/latest/observability/logging/log_collection_forwarding/log-forwarding.html[OpenShift docs] for available parameters.
+
+
 == `clusterLogForwarding`
 
-=== `clusterLogForwarding.enabled`
-
-[horizontal]
-type:: boolean
-default:: `false`
-
-Enables log forwarding for the cluster.
-
-=== `clusterLogForwarding.forwarders`
-
-[horizontal]
-type:: dictionary
-default:: {}
-
-Each key in this dictionary holds the parameters for an `.spec.outputs` object.
-
-See the https://docs.openshift.com/container-platform/4.16/observability/logging/log_collection_forwarding/configuring-log-forwarding.html#logging-create-clf_configuring-log-forwarding[OpenShift docs] for available parameters.
-
-=== `clusterLogForwarding.namespace_groups`
-
-[horizontal]
-type:: dictionary
-default:: {}
-
-Customization for the logging of a specified group of namespaces.
-
-Enabling forwarders will send the logs of the specified namespaces to a third-party log aggregator.
-For some log aggregation systems you may need to deploy a separate log forwarder.
-
-Enable json parsing for a 'namespace_group' only makes sense if the logs are forwarded to the clusters default elasticsearch instance. Therefor 'default' will automatically be added to the forwarders.
-
-[source,yaml]
-----
-clusterLogForwarding:
-  namespace_groups:
-    my-group: <1>
-      namespaces: <2>
-        - my-namespace
-      forwarders: <3>
-        - splunk-forwarder
-      json: true <4>
-      detectMultilineErrors: true <5>
-----
-
-<1> Namespace to configure.
-<2> List of namespaces.
-<3> List of forwarders (defined in `clusterLogForwarding.forwarders`).
-<4> Enable json logging only for defined namespaces.
-<5> Enable detecting multiline errors for defined namespaces.
+IMPORTANT: `clusterLogForwarding` is deprecated, please use `clusterLogForwarder`
 
 
-=== `clusterLogForwarding.application_logs`
-
-[horizontal]
-type:: dictionary
-default:: {}
-
-Customization for the logging of all applications.
-
-Enabling forwarders will send the logs of all namespaces to a third-party log aggregator.
-For some log aggregation systems you may need to deploy a separate log forwarder.
-
-[source,yaml]
-----
-clusterLogForwarding:
-  application_logs:
-    forwarders: <1>
-      - splunk-forwarder
-    json: true <2>
-    detectMultilineErrors: true <3>
-----
-
-<1> List of forwarders (defined in `clusterLogForwarding.forwarders`).
-<2> Enable json logging for all applications.
-<3> Enable detecting multiline errors for all applications.
-
-
-=== `clusterLogForwarding.infrastructure_logs`
-
-[horizontal]
-type:: dictionary
-default::
-+
-[source,yaml]
-----
-clusterLogForwarding:
-  infrastructure_logs:
-    enabled: true
-----
-
-Customization for the logging of `openshift*`, `kube*`, or `default` projects.
-
-Enabled by default.
-
-Enabling forwarders will send the logs of all namespaces to a third-party log aggregator.
-For some log aggregation systems you may need to deploy a separate log forwarder.
-
-[source,yaml]
-----
-clusterLogForwarding:
-  infrastructure_logs:
-    forwarders: <1>
-      - splunk-forwarder
-    json: true <2>
-----
-
-<1> List of forwarders (defined in `clusterLogForwarding.forwarders`).
-<2> Enable json logging for all applications.
-
-
-=== `clusterLogForwarding.audit_logs`
-
-[horizontal]
-type:: dictionary
-default::
-+
-[source,yaml]
-----
-clusterLogForwarding:
-  audit_logs:
-    enabled: false
-----
-
-Customization for the logging of https://docs.openshift.com/container-platform/latest/security/audit-log-policy-config.html[audit logs].
-
-Disabled by default.
-
-Enabling forwarders will send the logs of all namespaces to a third-party log aggregator.
-For some log aggregation systems you may need to deploy a separate log forwarder.
-
-[source,yaml]
-----
-clusterLogForwarding:
-  audit_logs:
-    forwarders: <1>
-      - splunk-forwarder
-    json: true <2>
-----
-
-<1> List of forwarders (defined in `clusterLogForwarding.forwarders`).
-<2> Enable json logging for all applications.
-
-
-=== `clusterLogForwarding.json`
-
-[horizontal]
-type:: dictionary
-default:: see below
-
-Setting `json.enabled` is required for json parsing to be available. You need to additionally enable it in `clusterLogForwarding.application_logs` or `clusterLogForwarding.namespace_groups`, based on your needs, to actually parse the logs.
-
-[source,yaml]
-----
-clusterLogForwarding:
-  json:
-    enabled: false <1>
-    typekey: 'kubernetes.labels.logFormat' <2>
-    typename: 'nologformat' <3>
-----
-
-<1> By default JSON parsing is disabled.
-<2> The value of that field, if present, is used to construct the index name.
-<3> If `typekey` isn't set or its key isn't present, the value of this field is used to construct the index name.
-
-See the https://docs.openshift.com/container-platform/latest/observability/logging/log_collection_forwarding/cluster-logging-enabling-json-logging.html[OpenShift docs] for a detailed explanation.
-
-
-== Example
+== Examples
 
 [source,yaml]
 ----
@@ -541,36 +385,40 @@ clusterLogging:
 
 [source,yaml]
 ----
-clusterLogForwarding:
-  enabled: true
-  forwarders:
+clusterLogForwarder:
+  outputs:
     splunk-forwarder:
       secret:
         name: splunk-forwarder
       type: fluentdForward
       url: tls://splunk-forwarder:24224
-  application_logs:
-    forwarders:
-      - splunk-forwarder
+  pipelines:
+    application-logs:
+      outputRefs:
+        - splunk-forwarder
 ----
 
 === Forward logs for certain namespaces to third-party
 
 [source,yaml]
 ----
-clusterLogForwarding:
-  enabled: true
-  forwarders:
+clusterLogForwarder:
+  inputs:
+    my-apps:
+      application:
+        namespaces:
+          - my-namespace
+  outputs:
     splunk-forwarder:
       secret:
         name: splunk-forwarder
       type: fluentdForward
       url: tls://splunk-forwarder:24224
-  namespace_groups:
-    my-group:
-      namespaces:
-        - my-namespace
-      forwarders:
+  pipelines:
+    my-apps:
+      inputRefs:
+        - my-apps
+      outputRefs:
         - splunk-forwarder
 ----
 
@@ -578,25 +426,27 @@ clusterLogForwarding:
 
 [source,yaml]
 ----
-clusterLogForwarding:
-  enabled: true
-  application_logs:
-    json: true
-  json:
-    enabled: true
+clusterLogForwarder:
+  pipelines:
+    application-logs:
+      parse: json
 ----
 
 === Enable JSON parsing for certain namespaces
 
 [source,yaml]
 ----
-clusterLogForwarding:
-  enabled: true
-  namespace_groups:
-    my-group:
-      namespaces:
-        - my-namespace
-      json: true
-  json:
-    enabled: true
+clusterLogForwarder:
+  inputs:
+    my-apps:
+      application:
+        namespaces:
+          - my-namespace
+  pipelines:
+    my-apps:
+      inputRefs:
+        - my-apps
+      outputRefs:
+        - default
+      parse: json
 ----

--- a/docs/modules/ROOT/partials/nav.adoc
+++ b/docs/modules/ROOT/partials/nav.adoc
@@ -7,6 +7,7 @@
 * xref:how-tos/upgrade-v0.1-v1.x.adoc[Upgrade from v0.1.0 to v1.x]
 * xref:how-tos/upgrade-v1.x-v2.x.adoc[Upgrade from v1.x to v2.x]
 * xref:how-tos/upgrade-v2.x-v3.x.adoc[Upgrade from v2.x to v3.x]
+* xref:how-tos/upgrade-v3.x-v4.x.adoc[Upgrade from v3.x to v4.x]
 * xref:how-tos/switch-to-lokistack.adoc[Switch to Lokistack]
 
 .Alert runbooks

--- a/tests/elasticsearch.yml
+++ b/tests/elasticsearch.yml
@@ -11,19 +11,11 @@ parameters:
       - type: https
         source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v2.9.0/lib/openshift4-monitoring-alert-patching.libsonnet
         output_path: vendor/lib/alert-patching.libsonnet
-      - type: https
-        source: https://raw.githubusercontent.com/projectsyn/component-patch-operator/v1.1.0/lib/patch-operator.libsonnet
-        output_path: vendor/lib/patch-operator.libsonnet
     compile:
       - input_type: jsonnet
         input_paths:
           - tests/console-patch.jsonnet
         output_path: console-patching/
-
-  patch_operator:
-    namespace: syn-patch-operator
-    patch_serviceaccount:
-      name: syn-patch-operator
 
   openshift4_operators:
     defaultInstallPlanApproval: Automatic

--- a/tests/forwardingonly.yml
+++ b/tests/forwardingonly.yml
@@ -28,6 +28,3 @@ parameters:
         enabled: false
       elasticsearch:
         enabled: false
-
-    clusterLogForwarding:
-      enabled: true

--- a/tests/golden/forwardingonly/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
+++ b/tests/golden/forwardingonly/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
@@ -1,9 +1,0 @@
-apiVersion: logging.openshift.io/v1
-kind: ClusterLogForwarder
-metadata:
-  annotations: {}
-  labels:
-    name: instance
-  name: instance
-  namespace: openshift-logging
-spec: {}

--- a/tests/golden/legacy/openshift4-logging/console-patching/openshift4_console_params.yaml
+++ b/tests/golden/legacy/openshift4-logging/console-patching/openshift4_console_params.yaml
@@ -1,0 +1,3 @@
+config:
+  plugins:
+    - logging-view-plugin

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/00_namespace.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/00_namespace.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ''
+  labels:
+    name: openshift-logging
+    openshift.io/cluster-monitoring: 'true'
+  name: openshift-logging

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/10_operator_group.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/10_operator_group.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  targetNamespaces:
+    - openshift-logging

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -1,0 +1,43 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: cluster-logging
+  name: cluster-logging
+  namespace: openshift-logging
+spec:
+  channel: stable-5.9
+  config:
+    resources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+  installPlanApproval: Automatic
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-operators-redhat
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations: {}
+  labels:
+    name: loki-operator
+  name: loki-operator
+  namespace: openshift-operators-redhat
+spec:
+  channel: stable-5.9
+  config:
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 50m
+        memory: 381Mi
+  installPlanApproval: Automatic
+  name: loki-operator
+  source: openshift-operators-redhat
+  sourceNamespace: openshift-operators-redhat

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/30_cluster_logging.yaml
@@ -1,0 +1,17 @@
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: instance
+  name: instance
+  namespace: openshift-logging
+spec:
+  collection:
+    type: vector
+  logStore:
+    lokistack:
+      name: loki
+    type: lokistack
+  managementState: Managed

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
@@ -16,23 +16,26 @@ spec:
   outputs:
     - name: custom-forwarder
       type: syslog
+    - elasticsearch:
+        version: 8
+      name: my-other-forwarder
+      type: elasticsearch
   pipelines:
     - inputRefs:
         - application
       name: application-logs
       outputRefs:
+        - my-other-forwarder
         - default
-        - custom-forwarder
-    - inputRefs:
-        - audit
-      name: audit-logs
-      outputRefs:
-        - custom-forwarder
-    - inputRefs:
+        - my-forwarder
+      parse: json
+    - detectMultilineErrors: true
+      inputRefs:
         - infrastructure
       name: infrastructure-logs
       outputRefs:
         - default
+      parse: json
     - inputRefs:
         - my-apps
       name: my-apps

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_ingester_fix.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_ingester_fix.yaml
@@ -1,0 +1,153 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  labels:
+    name: loki-ingester-check
+  name: loki-ingester-check
+  namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: loki-ingester-check
+  name: loki-ingester-check
+  namespace: openshift-logging
+rules:
+  - apiGroups:
+      - ''
+    resources:
+      - pods
+      - pods/exec
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+      - patch
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: loki-ingester-check
+  name: loki-ingester-check
+  namespace: openshift-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: loki-ingester-check
+subjects:
+  - kind: ServiceAccount
+    name: loki-ingester-check
+---
+apiVersion: v1
+data:
+  wal-check.sh: |
+    #!/bin/bash
+
+    set -e -o pipefail
+
+    # Check if pod is in stuck state.
+    function check_pod() {
+      POD_NAME="loki-ingester-${1}"
+      echo "checking POD ${POD_NAME}"
+      PHASE=$(kubectl -n openshift-logging get po ${POD_NAME} -oyaml | yq '.status.phase')
+      if [ ${PHASE} != "Running" ]; then
+        return 0
+      fi
+      READY=$(kubectl -n openshift-logging get po ${POD_NAME} -oyaml | yq '.status.conditions[] | select(.type == "ContainersReady") | .status')
+      if [ ${READY} == "True" ]; then
+        return 0
+      fi
+      return 1
+    }
+
+    # Check directories of pod and remove non-existing checkpoint if present.
+    function check_dir() {
+      shopt -s extglob
+      POD_NAME="loki-ingester-${1}"
+      echo "checking DIR ${POD_NAME}"
+      DIR_CHP=$(kubectl -n openshift-logging exec -i ${POD_NAME} -- ls /tmp/wal | grep -o "^checkpoint\.[0-9]*$")
+      PATTERN=$(echo ${DIR_CHP} | sed 's/[^0-9]*//g')
+      DIR_WAL=$(kubectl -n openshift-logging exec -i ${POD_NAME} -- ls /tmp/wal | grep -o "^0*${PATTERN}$" || exit 0)
+      if [ -z $DIR_WAL ]; then
+        kubectl -n openshift-logging exec -i ${POD_NAME} -- rm -rf /tmp/wal/${DIR_CHP}
+        kubectl -n openshift-logging delete po ${POD_NAME}
+      fi
+    }
+
+    # Check if pods are in stuck state for longer than ${SLEEP_TIME}.
+    # Only fix 1 pod at a time and immediatly exit if it is fixed.
+    function fix_pod() {
+      if ! check_pod $1; then
+        echo "stuck POD, waiting ${SLEEP_TIME}"
+        sleep ${SLEEP_TIME}
+        if ! check_pod $1; then
+          check_dir $1
+          exit 0
+        fi
+      fi
+    }
+
+    fix_pod 0
+    fix_pod 1
+
+    exit 0
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: loki-ingester-check
+  name: loki-ingester-check
+  namespace: openshift-logging
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  annotations: {}
+  labels:
+    name: loki-ingester-check
+  name: loki-ingester-check
+  namespace: openshift-logging
+spec:
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 0
+  jobTemplate:
+    spec:
+      activeDeadlineSeconds: 360
+      backoffLimit: 1
+      template:
+        spec:
+          containers:
+            - command:
+                - /usr/local/bin/wal-check.sh
+              env:
+                - name: SLEEP_TIME
+                  value: 2m
+              image: quay.io/appuio/oc:v4.14
+              imagePullPolicy: IfNotPresent
+              name: check-pod
+              ports: []
+              stdin: false
+              tty: false
+              volumeMounts:
+                - mountPath: /usr/local/bin/wal-check.sh
+                  name: wal-check
+                  readOnly: true
+                  subPath: wal-check.sh
+          nodeSelector:
+            node-role.kubernetes.io/infra: ''
+          restartPolicy: Never
+          serviceAccountName: loki-ingester-check
+          volumes:
+            - configMap:
+                defaultMode: 364
+                name: loki-ingester-check
+              name: wal-check
+  schedule: '*/10 * * * *'

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_logstore.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_logstore.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+data: {}
+kind: Secret
+metadata:
+  annotations: {}
+  labels:
+    name: loki-logstore
+  name: loki-logstore
+stringData:
+  access_key_id: ''
+  access_key_secret: ''
+  bucketnames: c-green-test-1234-logstore
+  endpoint: ''
+type: Opaque

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_netpol.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_netpol.yaml
@@ -1,0 +1,54 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-console-logging-view-plugin
+  name: allow-console-logging-view-plugin
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: console
+              component: ui
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+      ports:
+        - port: 9443
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/created-by: openshift-logging_instance
+      app.kubernetes.io/name: logging-view-plugin
+  policyTypes:
+    - Ingress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations: {}
+  labels:
+    name: allow-console-logging-lokistack-gateway
+  name: allow-console-logging-lokistack-gateway
+spec:
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: console
+              component: ui
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+      ports:
+        - port: 8080
+          protocol: TCP
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: lokistack-gateway
+      app.kubernetes.io/instance: loki
+      app.kubernetes.io/name: lokistack
+  policyTypes:
+    - Ingress

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_operator_metrics_token.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_operator_metrics_token.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: Prune=false,Delete=false
+    kubernetes.io/service-account.name: loki-operator-controller-manager-metrics-reader
+  labels:
+    name: loki-operator-controller-manager-metrics-token
+  name: loki-operator-controller-manager-metrics-token
+  namespace: openshift-operators-redhat
+type: kubernetes.io/service-account-token

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_rbac.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-loki-cluster-reader
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: 'true'
+  name: syn:loki:cluster-reader
+rules:
+  - apiGroups:
+      - loki.grafana.com
+    resourceNames:
+      - logs
+    resources:
+      - application
+      - infrastructure
+    verbs:
+      - get

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_stack.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/50_loki_stack.yaml
@@ -1,0 +1,60 @@
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  labels:
+    name: loki
+  name: loki
+spec:
+  limits:
+    global:
+      ingestion:
+        ingestionBurstSize: 9
+        ingestionRate: 5
+  size: 1x.demo
+  storage:
+    schemas:
+      - effectiveDate: '2022-06-01'
+        version: v12
+      - effectiveDate: '2024-09-01'
+        version: v13
+    secret:
+      name: loki-logstore
+      type: s3
+  storageClassName: ''
+  template:
+    compactor:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 1
+    distributor:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    gateway:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    indexGateway:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    ingester:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    querier:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    queryFrontend:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 2
+    ruler:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ''
+      replicas: 1
+  tenants:
+    mode: openshift-logging

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/60_collector_alerts.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/60_collector_alerts.yaml
@@ -1,0 +1,127 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: syn-collector-rules
+  name: syn-collector-rules
+  namespace: openshift-logging
+spec:
+  groups:
+    - name: logging_collector.alerts
+      rules:
+        - alert: SYN_CollectorNodeDown
+          annotations:
+            message: Prometheus could not scrape {{ $labels.namespace }}/{{ $labels.pod
+              }} collector component for more than 10m.
+            summary: Collector cannot be scraped
+          expr: |
+            up{app_kubernetes_io_component = "collector", app_kubernetes_io_part_of = "cluster-logging"} == 0
+          for: 10m
+          labels:
+            service: collector
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_CollectorHighErrorRate
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by {{ $labels.namespace
+              }}/{{ $labels.pod }} collector component.'
+            summary: '{{ $labels.namespace }}/{{ $labels.pod }} collector component
+              errors are high'
+          expr: |
+            100 * (
+                collector:log_num_errors:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
+              /
+                collector:received_events:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
+              ) > 0.001
+          for: 15m
+          labels:
+            service: collector
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_CollectorVeryHighErrorRate
+          annotations:
+            message: '{{ $value }}% of records have resulted in an error by {{ $labels.namespace
+              }}/{{ $labels.pod }} collector component.'
+            summary: '{{ $labels.namespace }}/{{ $labels.pod }} collector component
+              errors are very high'
+          expr: |
+            100 * (
+                collector:log_num_errors:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
+              /
+                collector:received_events:sum_rate{app_kubernetes_io_part_of = "cluster-logging"}
+              ) > 0.05
+          for: 15m
+          labels:
+            service: collector
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_ElasticsearchDeprecation
+          annotations:
+            message: The OpenShift Elasticsearch Operator is deprecated and is planned
+              to be removed in a future release. Red Hat provides bug fixes and support
+              for this feature during the current release lifecycle, but this feature
+              no longer receives enhancements. As an alternative to using the OpenShift
+              Elasticsearch Operator to manage the default log storage, you can use
+              the Loki Operator.
+            summary: Detected Elasticsearch as the in-cluster storage which is deprecated
+              and will be removed in a future release.
+          expr: |
+            sum(kube_pod_labels{namespace="openshift-logging",label_component='elasticsearch'}) > 0
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            service: storage
+            severity: Warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_FluentdDeprecation
+          annotations:
+            message: Fluentd is deprecated and is planned to be removed in a future
+              release. Red Hat provides bug fixes and support for this feature during
+              the current release lifecycle, but this feature no longer receives enhancements.
+              As an alternative to Fluentd, you can use Vector instead.
+            summary: Detected Fluentd as the collector which is deprecated and will
+              be removed in a future release.
+          expr: |
+            sum(kube_pod_labels{namespace="openshift-logging", label_implementation='fluentd', label_app_kubernetes_io_managed_by="cluster-logging-operator"}) > 0
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            service: collector
+            severity: Warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_KibanaDeprecation
+          annotations:
+            message: The Kibana web console is now deprecated and is planned to be
+              removed in a future logging release.
+            summary: Detected Kibana as the visualization which is deprecated and
+              will be removed in a future release.
+          expr: |
+            sum(kube_pod_labels{namespace="openshift-logging",label_component='kibana'}) > 0
+          for: 5m
+          labels:
+            namespace: openshift-logging
+            service: visualization
+            severity: Warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_DiskBufferUsage
+          annotations:
+            message: 'Collectors potentially consuming too much node disk, {{ $value
+              }}% '
+            summary: Detected consuming too much node disk on $labels.hostname host
+          expr: "(label_replace(sum by(hostname) (vector_buffer_byte_size{component_kind='sink',\
+            \ buffer_type='disk'}), 'instance', '$1', 'hostname', '(.*)') \n/ on(instance)\
+            \ group_left() sum by(instance) (node_filesystem_size_bytes{mountpoint='/var'}))\
+            \ * 100  > 15\n"
+          for: 5m
+          labels:
+            service: collector
+            severity: Warning
+            syn: 'true'
+            syn_component: openshift4-logging

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/60_lokistack_alerts.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/60_lokistack_alerts.yaml
@@ -1,0 +1,225 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations: {}
+  labels:
+    name: syn-loki-logging-rules
+  name: syn-loki-logging-rules
+  namespace: openshift-logging
+spec:
+  groups:
+    - name: logging_loki.alerts
+      rules:
+        - alert: SYN_LokiRequestErrors
+          annotations:
+            message: '{{ $labels.job }} {{ $labels.route }} is experiencing {{ printf
+              "%.2f" $value }}% errors.'
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Request-Errors
+            summary: At least 10% of requests are responded by 5xx server errors.
+          expr: |
+            sum(
+              job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m{status_code=~"5.."}
+            ) by (job, namespace, route)
+            /
+            sum(
+              job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m
+            ) by (job, namespace, route)
+            * 100
+            > 10
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiStackWriteRequestErrors
+          annotations:
+            message: '{{ printf "%.2f" $value }}% of write requests from {{ $labels.job
+              }} in {{ $labels.namespace }} are returned with server errors.'
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#LokiStack-Write-Request-Errors
+            summary: At least 10% of write requests to the lokistack-gateway are responded
+              with 5xx server errors.
+          expr: |
+            sum(
+              code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{code=~"5..", handler="push"}
+            ) by (job, namespace)
+            /
+            sum(
+              code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{handler="push"}
+            ) by (job, namespace)
+            * 100
+            > 10
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiStackReadRequestErrors
+          annotations:
+            message: '{{ printf "%.2f" $value }}% of query requests from {{ $labels.job
+              }} in {{ $labels.namespace }} are returned with server errors.'
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#LokiStack-Read-Request-Errors
+            summary: At least 10% of query requests to the lokistack-gateway are responded
+              with 5xx server errors.
+          expr: |
+            sum(
+              code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{code=~"5..", handler=~"query|query_range|label|labels|label_values"}
+            ) by (job, namespace)
+            /
+            sum(
+              code_handler_job_namespace:lokistack_gateway_http_requests:irate1m{handler=~"query|query_range|label|labels|label_values"}
+            ) by (job, namespace)
+            * 100
+            > 10
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiRequestPanics
+          annotations:
+            message: '{{ $labels.job }} is experiencing an increase of {{ $value }}
+              panics.'
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Request-Panics
+            summary: A panic was triggered.
+          expr: |
+            sum(
+              increase(
+                loki_panic_total[10m]
+              )
+            ) by (job, namespace)
+            > 0
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiRequestLatency
+          annotations:
+            message: '{{ $labels.job }} {{ $labels.route }} is experiencing {{ printf
+              "%.2f" $value }}s 99th percentile latency.'
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Request-Latency
+            summary: The 99th percentile is experiencing high latency (higher than
+              1 second).
+          expr: |
+            histogram_quantile(0.99,
+              sum(
+                irate(
+                  loki_request_duration_seconds_bucket{route!~"(?i).*tail.*"}[1m]
+                )
+              ) by (job, le, namespace, route)
+            )
+            > 1
+          for: 15m
+          labels:
+            severity: critical
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiTenantRateLimit
+          annotations:
+            message: '{{ $labels.job }} {{ $labels.route }} is experiencing 429 errors.'
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Tenant-Rate-Limit
+            summary: At least 10% of requests are responded with the rate limit error
+              code.
+          expr: |
+            sum(
+              job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m{status_code="429"}
+            ) by (job, namespace, route)
+            /
+            sum(
+              job_namespace_route_statuscode:loki_request_duration_seconds_count:irate1m
+            ) by (job, namespace, route)
+            * 100
+            > 10
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiStorageSlowWrite
+          annotations:
+            message: The storage path is experiencing slow write response rates.
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Storage-Slow-Write
+            summary: The storage path is experiencing slow write response rates.
+          expr: |
+            histogram_quantile(0.99,
+              sum(
+                job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation="WRITE"}
+              ) by (job, le, namespace)
+            )
+            > 1
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiStorageSlowRead
+          annotations:
+            message: The storage path is experiencing slow read response rates.
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Storage-Slow-Read
+            summary: The storage path is experiencing slow read response rates.
+          expr: |
+            histogram_quantile(0.99,
+              sum(
+                job_le_namespace_operation:loki_boltdb_shipper_request_duration_seconds_bucket:rate5m{operation="Shipper.Query"}
+              ) by (job, le, namespace)
+            )
+            > 5
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiWritePathHighLoad
+          annotations:
+            message: The write path is experiencing high load.
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Write-Path-High-Load
+            summary: The write path is experiencing high load, causing backpressure
+              storage flushing.
+          expr: |
+            sum(
+              loki_ingester_wal_replay_flushing
+            ) by (job, namespace)
+            > 0
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokiReadPathHighLoad
+          annotations:
+            message: The read path is experiencing high load.
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Loki-Read-Path-High-Load
+            summary: The read path has high volume of queries, causing longer response
+              times.
+          expr: |
+            histogram_quantile(0.99,
+              sum(
+                rate(
+                  loki_logql_querystats_latency_seconds_bucket[5m]
+                )
+              ) by (job, le, namespace)
+            )
+            > 30
+          for: 15m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging
+        - alert: SYN_LokistackSchemaUpgradesRequired
+          annotations:
+            message: |-
+              The LokiStack "{{ $labels.stack_name }}" in namespace "{{ $labels.stack_namespace }}" is using a storage schema
+              configuration that does not contain the latest schema version. It is recommended to update the schema
+              configuration to update the schema version to the latest version in the future.
+            runbook_url: https://github.com/grafana/loki/blob/main/operator/docs/lokistack/sop.md#Lokistack-Schema-Upgrades-Required
+            summary: One or more of the deployed LokiStacks contains an outdated storage
+              schema configuration.
+          expr: |
+            sum (
+              lokistack_status_condition{reason="StorageNeedsSchemaUpdate",status="true"}
+            ) by (stack_namespace, stack_name)
+            > 0
+          for: 1m
+          labels:
+            severity: warning
+            syn: 'true'
+            syn_component: openshift4-logging

--- a/tests/legacy.yml
+++ b/tests/legacy.yml
@@ -1,0 +1,3 @@
+# Overwrite parameters here
+
+# parameters: {...}

--- a/tests/legacy.yml
+++ b/tests/legacy.yml
@@ -1,3 +1,57 @@
-# Overwrite parameters here
+applications:
+  - openshift4-operators as openshift-operators-redhat
+  - openshift4-monitoring
 
-# parameters: {...}
+parameters:
+  kapitan:
+    dependencies:
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-operators/v1.0.2/lib/openshift4-operators.libsonnet
+        output_path: vendor/lib/openshift4-operators.libsonnet
+      - type: https
+        source: https://raw.githubusercontent.com/appuio/component-openshift4-monitoring/v2.9.0/lib/openshift4-monitoring-alert-patching.libsonnet
+        output_path: vendor/lib/alert-patching.libsonnet
+    compile:
+      - input_type: jsonnet
+        input_paths:
+          - tests/console-patch.jsonnet
+        output_path: console-patching/
+
+  openshift4_operators:
+    defaultInstallPlanApproval: Automatic
+    defaultSource: openshift-operators-redhat
+    defaultSourceNamespace: openshift-operators-redhat
+
+  openshift4_logging:
+    clusterLogForwarding:
+      enabled: true
+      forwarders:
+        custom-forwarder:
+          type: syslog
+        my-other-forwarder:
+          type: elasticsearch
+          elasticsearch:
+            version: 8
+      namespace_groups:
+        my-apps:
+          namespaces:
+            - app-one
+            - app-two
+          forwarders:
+            - custom-forwarder
+          json: true
+      json:
+        enabled: true
+      application_logs:
+        json: true
+        forwarders:
+          - my-other-forwarder
+      infrastructure_logs:
+        json: true
+        detectMultilineErrors: true
+
+    clusterLogForwarder:
+      pipelines:
+        application-logs:
+          outputRefs:
+            - my-forwarder

--- a/tests/master.yml
+++ b/tests/master.yml
@@ -26,16 +26,26 @@ parameters:
     channel: 'stable'
     alerts: 'master'
 
-    clusterLogForwarding:
-      enabled: true
-      forwarders:
+    clusterLogForwarder:
+      inputs:
+        my-apps:
+          application:
+            namespaces:
+              - app-one
+              - app-two
+      outputs:
         custom-forwarder:
           type: syslog
-      namespace_groups:
-        my-apps:
-          namespaces:
-            - app-one
-            - app-two
-          forwarders:
+      pipelines:
+        application-logs:
+          outputRefs:
             - custom-forwarder
-          json: true
+        my-apps:
+          parse: json
+          inputRefs:
+            - my-apps
+          outputRefs:
+            - custom-forwarder
+        audit-logs:
+          outputRefs:
+            - custom-forwarder

--- a/tests/multilineerr.yml
+++ b/tests/multilineerr.yml
@@ -23,8 +23,8 @@ parameters:
     defaultSourceNamespace: openshift-operators-redhat
 
   openshift4_logging:
-    clusterLogForwarding:
-      enabled: true
-      application_logs:
-        json: true
-        detectMultilineErrors: true
+    clusterLogForwarder:
+      pipelines:
+        application-logs:
+          parse: json
+          detectMultilineErrors: true


### PR DESCRIPTION
With this commit configuring the ClusterLogForwarder resource will be done with a new parameter `openshift4_logging.clusterLogForwarder`, which will follow the upstream convention / spec.

The old parameter `openshift4_logging.clusterLogForwarding` is deprecated, but existing legacy config will be respected.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
