### PR TITLE
Fix configuring LogForwarding pipelines only when needed

### DIFF
--- a/component/config_forwarding.libsonnet
+++ b/component/config_forwarding.libsonnet
@@ -161,11 +161,11 @@ local patchPipelineDefaults = {
   local auditPipeline = std.get(std.get(params.clusterLogForwarder, 'pipelines', {}), 'audit-logs', {}),
 
   pipelines: {
-    'application-logs': {
+    [if !forwardingOnly || std.length(appsPipeline) > 0 then 'application-logs']: {
       inputRefs: [ 'application' ],
       outputRefs: pipelineOutputRefs(appsPipeline),
     },
-    'infrastructure-logs': {
+    [if !forwardingOnly || std.length(infraPipeline) > 0 then 'infrastructure-logs']: {
       inputRefs: [ 'infrastructure' ],
       outputRefs: pipelineOutputRefs(infraPipeline),
     },


### PR DESCRIPTION
This commit ensures that infrastructure or application logs pipelines only get configured when enabled in forwarding only mode.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
