### PR TITLE
Fix initial sync for `ClusterLogForwarder` resources

### DIFF
--- a/component/config_forwarding.libsonnet
+++ b/component/config_forwarding.libsonnet
@@ -225,6 +225,11 @@ local unfoldSpecs(specs) = {
 // ClusterLogForwarder:
 // Create definitive ClusterLogForwarder resource from specs.
 local clusterLogForwarder = lib.ClusterLogForwarder(params.namespace, 'instance') {
+  metadata+: {
+    annotations+: {
+      'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+    },
+  },
   spec: unfoldSpecs(clusterLogForwarderSpec),
 };
 
@@ -243,6 +248,11 @@ local namespaceLogForwarder = [
   local serviceAccount = std.get(specs, 'serviceAccountName', utils.namespacedName(forwarder).name);
 
   lib.ClusterLogForwarder(namespace, name) {
+    metadata+: {
+      annotations+: {
+        'argocd.argoproj.io/sync-options': 'SkipDryRunOnMissingResource=true',
+      },
+    },
     spec: { serviceAccountName: serviceAccount } + com.makeMergeable(unfoldSpecs(specs)),
   }
   for forwarder in std.objectFields(params.namespaceLogForwarder)

--- a/tests/golden/legacy/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
+++ b/tests/golden/legacy/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
@@ -1,7 +1,8 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: instance
   name: instance

--- a/tests/golden/master/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
@@ -1,7 +1,8 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: instance
   name: instance

--- a/tests/golden/master/openshift4-logging/openshift4-logging/32_namespace_logforwarding.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/32_namespace_logforwarding.yaml
@@ -1,7 +1,8 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: bar
   name: bar
@@ -27,7 +28,8 @@ spec:
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: hands
   name: hands

--- a/tests/golden/multilineerr/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
+++ b/tests/golden/multilineerr/openshift4-logging/openshift4-logging/31_cluster_logforwarding.yaml
@@ -1,7 +1,8 @@
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogForwarder
 metadata:
-  annotations: {}
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
   labels:
     name: instance
   name: instance


### PR DESCRIPTION
Add `SkipDryRunOnMissingResource=true` to `ClusterLogForwarder` so that the initial sync of the openshift4-logging ArgoCD app can succeed.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
