### PR TITLE
Fix Logs not sent to LokiStack

### DIFF
--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/40_log_forwarder.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/40_log_forwarder.yaml
@@ -17,5 +17,26 @@ spec:
       - key: storagenode
         operator: Exists
   managementState: Managed
+  outputs:
+    - lokiStack:
+        authentication:
+          token:
+            from: serviceAccount
+        target:
+          name: loki
+          namespace: openshift-logging
+      name: default-lokistack
+      tls:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+      type: lokiStack
+  pipelines:
+    - inputRefs:
+        - application
+        - infrastructure
+      name: default-lokistack
+      outputRefs:
+        - default-lokistack
   serviceAccount:
     name: logcollector

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/40_log_forwarder_rbac.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/40_log_forwarder_rbac.yaml
@@ -61,3 +61,21 @@ subjects:
   - kind: ServiceAccount
     name: logcollector
     namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-50'
+  labels:
+    name: logcollector-log-writer
+  name: logcollector-log-writer
+  namespace: openshift-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logging-collector-logs-writer
+subjects:
+  - kind: ServiceAccount
+    name: logcollector
+    namespace: openshift-logging

--- a/tests/golden/master/openshift4-logging/openshift4-logging/40_log_forwarder.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/40_log_forwarder.yaml
@@ -30,6 +30,19 @@ spec:
   outputs:
     - name: custom-forwarder
       type: syslog
+    - lokiStack:
+        authentication:
+          token:
+            from: serviceAccount
+        target:
+          name: loki
+          namespace: openshift-logging
+      name: default-lokistack
+      tls:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+      type: lokiStack
   pipelines:
     - name: application-logs
       outputRefs:
@@ -37,6 +50,12 @@ spec:
     - name: audit-logs
       outputRefs:
         - custom-forwarder
+    - inputRefs:
+        - application
+        - infrastructure
+      name: default-lokistack
+      outputRefs:
+        - default-lokistack
     - inputRefs:
         - my-apps
       name: my-apps

--- a/tests/golden/master/openshift4-logging/openshift4-logging/40_log_forwarder_rbac.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/40_log_forwarder_rbac.yaml
@@ -61,3 +61,21 @@ subjects:
   - kind: ServiceAccount
     name: logcollector
     namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-50'
+  labels:
+    name: logcollector-log-writer
+  name: logcollector-log-writer
+  namespace: openshift-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logging-collector-logs-writer
+subjects:
+  - kind: ServiceAccount
+    name: logcollector
+    namespace: openshift-logging

--- a/tests/golden/multilineerr/openshift4-logging/openshift4-logging/40_log_forwarder.yaml
+++ b/tests/golden/multilineerr/openshift4-logging/openshift4-logging/40_log_forwarder.yaml
@@ -17,9 +17,29 @@ spec:
       - key: storagenode
         operator: Exists
   managementState: Managed
+  outputs:
+    - lokiStack:
+        authentication:
+          token:
+            from: serviceAccount
+        target:
+          name: loki
+          namespace: openshift-logging
+      name: default-lokistack
+      tls:
+        ca:
+          configMapName: openshift-service-ca.crt
+          key: service-ca.crt
+      type: lokiStack
   pipelines:
     - detectMultilineErrors: true
       name: application-logs
       parse: json
+    - inputRefs:
+        - application
+        - infrastructure
+      name: default-lokistack
+      outputRefs:
+        - default-lokistack
   serviceAccount:
     name: logcollector

--- a/tests/golden/multilineerr/openshift4-logging/openshift4-logging/40_log_forwarder_rbac.yaml
+++ b/tests/golden/multilineerr/openshift4-logging/openshift4-logging/40_log_forwarder_rbac.yaml
@@ -61,3 +61,21 @@ subjects:
   - kind: ServiceAccount
     name: logcollector
     namespace: openshift-logging
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-wave: '-50'
+  labels:
+    name: logcollector-log-writer
+  name: logcollector-log-writer
+  namespace: openshift-logging
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: logging-collector-logs-writer
+subjects:
+  - kind: ServiceAccount
+    name: logcollector
+    namespace: openshift-logging


### PR DESCRIPTION
The ClusterLogForwarder did not have the definitions and permissions to insert logs into the builtin Loki Stack.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
