### PR TITLE
Change default LokiStack size to 1x.pico

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -27,7 +27,7 @@ parameters:
           endpoint: ''
           bucketnames: '${cluster:name}-logstore'
         spec:
-          size: 1x.demo
+          size: 1x.pico
           storage:
             schemas:
               - version: v12
@@ -40,11 +40,6 @@ parameters:
           storageClassName: ''
           tenants:
             mode: openshift-logging
-          limits:
-            global:
-              ingestion:
-                ingestionBurstSize: 9
-                ingestionRate: 5
       logmetrics:
         enabled: false
         spec:

--- a/component/log_lokistack.libsonnet
+++ b/component/log_lokistack.libsonnet
@@ -8,8 +8,15 @@ local po = import 'lib/patch-operator.libsonnet';
 local inv = kap.inventory();
 local loki = inv.parameters.openshift4_logging.components.lokistack;
 
-
 local lokistack_spec = {
+  [if loki.spec.size == '1x.demo' then 'limits']: {
+    global: {
+      ingestion: {
+        ingestionBurstSize: 9,
+        ingestionRate: 5,
+      },
+    },
+  },
   template: {
     compactor: {
       [if loki.spec.size == '1x.demo' then 'replicas']: 1,

--- a/docs/modules/ROOT/pages/references/parameters.adoc
+++ b/docs/modules/ROOT/pages/references/parameters.adoc
@@ -148,7 +148,7 @@ default::
 [source,yaml]
 ----
 spec:
-  size: 1x.extra-small
+  size: 1x.pico
   storage:
     schemas:
       - version: v13
@@ -159,14 +159,7 @@ spec:
   storageClassName: ''
   tenants:
     mode: openshift-logging
-  limits:
-    global:
-      ingestion:
-        ingestionBurstSize: 9 <1>
-        ingestionRate: 5 <2>
 ----
-<1> value in MiB (per push event)
-<2> value in MiB/s
 
 A dictionary holding the `.spec` for the LokiStack resource.
 

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/30_loki_stack.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/30_loki_stack.yaml
@@ -8,12 +8,7 @@ metadata:
     name: loki
   name: loki
 spec:
-  limits:
-    global:
-      ingestion:
-        ingestionBurstSize: 9
-        ingestionRate: 5
-  size: 1x.demo
+  size: 1x.pico
   storage:
     schemas:
       - effectiveDate: '2022-06-01'
@@ -28,34 +23,26 @@ spec:
     compactor:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 1
     distributor:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     gateway:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     indexGateway:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     ingester:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     querier:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     queryFrontend:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     ruler:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 1
   tenants:
     mode: openshift-logging

--- a/tests/golden/master/openshift4-logging/openshift4-logging/30_loki_stack.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/30_loki_stack.yaml
@@ -8,12 +8,7 @@ metadata:
     name: loki
   name: loki
 spec:
-  limits:
-    global:
-      ingestion:
-        ingestionBurstSize: 9
-        ingestionRate: 5
-  size: 1x.demo
+  size: 1x.pico
   storage:
     schemas:
       - effectiveDate: '2022-06-01'
@@ -28,34 +23,26 @@ spec:
     compactor:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 1
     distributor:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     gateway:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     indexGateway:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     ingester:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     querier:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     queryFrontend:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 2
     ruler:
       nodeSelector:
         node-role.kubernetes.io/infra: ''
-      replicas: 1
   tenants:
     mode: openshift-logging


### PR DESCRIPTION
OpenShift Logging 6.1 comes with a new size for the LokiStack. This will use the new size 1x.pico as default.




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
