### PR TITLE
Update cluster-observability-operator to stable/v1.x

### DIFF
--- a/component/main.jsonnet
+++ b/component/main.jsonnet
@@ -72,7 +72,7 @@ local lokistack = if lokiEnabled then operatorlib.managedSubscription(
 local observability = if lokiEnabled then operatorlib.managedSubscription(
   'openshift-operators-redhat',
   'cluster-observability-operator',
-  'development'
+  'stable'
 ) {
   metadata+: {
     annotations+: {

--- a/tests/golden/defaults/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/defaults/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -54,7 +54,7 @@ metadata:
   name: cluster-observability-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: development
+  channel: stable
   installPlanApproval: Automatic
   name: cluster-observability-operator
   source: openshift-operators-redhat

--- a/tests/golden/master/openshift4-logging/openshift4-logging/20_subscriptions.yaml
+++ b/tests/golden/master/openshift4-logging/openshift4-logging/20_subscriptions.yaml
@@ -54,7 +54,7 @@ metadata:
   name: cluster-observability-operator
   namespace: openshift-operators-redhat
 spec:
-  channel: development
+  channel: stable
   installPlanApproval: Automatic
   name: cluster-observability-operator
   source: openshift-operators-redhat


### PR DESCRIPTION
Change OLM channel of cluster-observability-operator to `stable`, 
as the documented `developement` channel got dropped.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
